### PR TITLE
Masquage des menus home et favoris.

### DIFF
--- a/vector/src/main/java/im/vector/activity/VectorHomeActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorHomeActivity.java
@@ -443,10 +443,11 @@ public class VectorHomeActivity extends RiotAppCompatActivity implements SearchV
         }
 
         final View selectedMenu;
+        //default is people view
         if (savedInstanceState != null) {
-            selectedMenu = mBottomNavigationView.findViewById(savedInstanceState.getInt(CURRENT_MENU_ID, R.id.bottom_action_home));
+            selectedMenu = mBottomNavigationView.findViewById(savedInstanceState.getInt(CURRENT_MENU_ID, R.id.bottom_action_people));
         } else {
-            selectedMenu = mBottomNavigationView.findViewById(R.id.bottom_action_home);
+            selectedMenu = mBottomNavigationView.findViewById(R.id.bottom_action_people);
         }
         if (selectedMenu != null) {
             selectedMenu.performClick();
@@ -463,13 +464,9 @@ public class VectorHomeActivity extends RiotAppCompatActivity implements SearchV
      * Display the TAB if it is required
      */
     private void showFloatingActionButton() {
-        if (null != mFloatingActionButton) {
-            if ((mCurrentMenuId == R.id.bottom_action_favourites) /*|| (mCurrentMenuId == R.id.bottom_action_groups)*/) {
-                mFloatingActionButton.setVisibility(View.GONE);
-            } else {
+//No more favourite action
                 mFloatingActionButton.show();
-            }
-        }
+
     }
 
     @Override
@@ -775,6 +772,8 @@ public class VectorHomeActivity extends RiotAppCompatActivity implements SearchV
         Fragment fragment = null;
 
         switch (item.getItemId()) {
+            //no more home nor favourite
+            /*
             case R.id.bottom_action_home:
                 Log.d(LOG_TAG, "onNavigationItemSelected HOME");
                 fragment = mFragmentManager.findFragmentByTag(TAG_FRAGMENT_HOME);
@@ -793,6 +792,7 @@ public class VectorHomeActivity extends RiotAppCompatActivity implements SearchV
                 mCurrentFragmentTag = TAG_FRAGMENT_FAVOURITES;
                 mSearchView.setQueryHint(getString(R.string.home_filter_placeholder_favorites));
                 break;
+                */
             case R.id.bottom_action_people:
                 Log.d(LOG_TAG, "onNavigationItemSelected PEOPLE");
                 fragment = mFragmentManager.findFragmentByTag(TAG_FRAGMENT_PEOPLE);
@@ -1033,12 +1033,15 @@ public class VectorHomeActivity extends RiotAppCompatActivity implements SearchV
     private Fragment getSelectedFragment() {
         Fragment fragment = null;
         switch (mCurrentMenuId) {
+            //no more home nor favourite
+            /*
             case R.id.bottom_action_home:
                 fragment = mFragmentManager.findFragmentByTag(TAG_FRAGMENT_HOME);
                 break;
             case R.id.bottom_action_favourites:
                 fragment = mFragmentManager.findFragmentByTag(TAG_FRAGMENT_FAVOURITES);
                 break;
+                */
             case R.id.bottom_action_people:
                 fragment = mFragmentManager.findFragmentByTag(TAG_FRAGMENT_PEOPLE);
                 break;
@@ -2011,19 +2014,22 @@ public class VectorHomeActivity extends RiotAppCompatActivity implements SearchV
         Set<Integer> menuIndexes = new HashSet<>(mBadgeViewByIndex.keySet());
 
         // the badges are not anymore displayed on the home tab
-        menuIndexes.remove(R.id.bottom_action_home);
+        //no more home
+        //menuIndexes.remove(R.id.bottom_action_home);
 
         for (Integer id : menuIndexes) {
             // use a map because contains is faster
             HashSet<String> filteredRoomIdsSet = new HashSet<>();
-
+            //no more favourite
+            /*
             if (id == R.id.bottom_action_favourites) {
                 List<Room> favRooms = mSession.roomsWithTag(RoomTag.ROOM_TAG_FAVOURITE);
 
                 for (Room room : favRooms) {
                     filteredRoomIdsSet.add(room.getRoomId());
                 }
-            } else if (id == R.id.bottom_action_people) {
+            } else */
+            if (id == R.id.bottom_action_people) {
                 filteredRoomIdsSet.addAll(mSession.getDirectChatRoomIdsList());
                 // Add direct chat invitations
                 for (Room room : roomSummaryByRoom.keySet()) {
@@ -2080,12 +2086,13 @@ public class VectorHomeActivity extends RiotAppCompatActivity implements SearchV
 
             int status = (0 != highlightCount) ? UnreadCounterBadgeView.HIGHLIGHTED :
                     ((0 != roomCount) ? UnreadCounterBadgeView.NOTIFIED : UnreadCounterBadgeView.DEFAULT);
-
+            //no more favourite
+            /*
             if (id == R.id.bottom_action_favourites) {
                 mBadgeViewByIndex.get(id).updateText((roomCount > 0) ? "\u2022" : "", status);
-            } else {
+            } else {*/
                 mBadgeViewByIndex.get(id).updateCounter(roomCount, status);
-            }
+            //}
         }
     }
 

--- a/vector/src/main/java/im/vector/util/RoomUtils.java
+++ b/vector/src/main/java/im/vector/util/RoomUtils.java
@@ -538,6 +538,8 @@ public class RoomUtils {
                                 moreActionListener.onToggleRoomNotifications(session, room.getRoomId());
                                 break;
                             }
+                            // no more home nor favorite so dont make possible the two next actions
+                            /*
                             case R.id.ic_action_select_fav: {
                                 if (isFavorite) {
                                     moreActionListener.moveToConversations(session, room.getRoomId());
@@ -553,7 +555,7 @@ public class RoomUtils {
                                     moreActionListener.moveToLowPriority(session, room.getRoomId());
                                 }
                                 break;
-                            }
+                            }*/
                             case R.id.ic_action_select_remove: {
                                 moreActionListener.onLeaveRoom(session, room.getRoomId());
                                 break;

--- a/vector/src/main/java/im/vector/util/RoomUtils.java
+++ b/vector/src/main/java/im/vector/util/RoomUtils.java
@@ -509,22 +509,22 @@ public class RoomUtils {
             final BingRulesManager bingRulesManager = session.getDataHandler().getBingRulesManager();
 
             if (bingRulesManager.isRoomNotificationsDisabled(room.getRoomId())) {
-                item = popup.getMenu().getItem(0);
+                item = popup.getMenu().findItem(R.id.ic_action_select_notifications);
                 item.setIcon(null);
             }
-
+/*
             if (!isFavorite) {
-                item = popup.getMenu().getItem(1);
+                item = popup.getMenu().findItem(R.id.ic_action_select_fav);
                 item.setIcon(null);
             }
 
             if (!isLowPrior) {
-                item = popup.getMenu().getItem(2);
+                item = popup.getMenu().findItem(R.id.ic_action_select_deprioritize);
                 item.setIcon(null);
             }
-
+*/
             if (session.getDirectChatRoomIdsList().indexOf(room.getRoomId()) < 0) {
-                item = popup.getMenu().getItem(3);
+                item = popup.getMenu().findItem(R.id.ic_action_select_direct_chat);
                 item.setIcon(null);
             }
 

--- a/vector/src/main/res/menu/bottom_navigation_main.xml
+++ b/vector/src/main/res/menu/bottom_navigation_main.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- define an empty title else lint fails -->
-    <item
+    <!-- disable first two icons item
         android:title=""
         android:id="@+id/bottom_action_home"
         android:enabled="true"
@@ -11,19 +11,19 @@
         android:title=""
         android:id="@+id/bottom_action_favourites"
         android:enabled="true"
-        android:icon="@drawable/ic_star_black_24dp" />
+        android:icon="@drawable/ic_star_black_24dp" / -->
 
     <item
         android:title=""
         android:id="@+id/bottom_action_people"
         android:enabled="true"
         android:icon="@drawable/ic_person_black_24dp" />
-
+    <!-- prefer the group icon for rooms on tchap -->
     <item
         android:title=""
         android:id="@+id/bottom_action_rooms"
         android:enabled="true"
-        android:icon="@drawable/riot_tab_rooms"/>
+        android:icon="@drawable/riot_tab_groups"/>
 
     <!--item
         android:title=""

--- a/vector/src/main/res/menu/vector_home_room_settings.xml
+++ b/vector/src/main/res/menu/vector_home_room_settings.xml
@@ -7,7 +7,7 @@
             android:icon="@drawable/ic_material_done"
             android:title="@string/room_settings_notifications" />
 
-        <item
+        <!-- item no more home nor favorite so dont allow these actions
             android:id="@+id/ic_action_select_fav"
             android:icon="@drawable/ic_material_done"
             android:title="@string/room_settings_favourite" />
@@ -15,7 +15,7 @@
         <item
             android:id="@+id/ic_action_select_deprioritize"
             android:icon="@drawable/ic_material_done"
-            android:title="@string/room_settings_de_prioritize" />
+            android:title="@string/room_settings_de_prioritize" / -->
 
         <item
             android:id="@+id/ic_action_select_direct_chat"
@@ -31,7 +31,7 @@
     <group android:id="@+id/add_shortcut_actions">
         <item
             android:id="@+id/ic_action_add_homescreen_shortcut"
-            android:title="Add Homescreen Shortcut" />
+            android:title="Créer un raccourci" />
     </group>
 
     <group android:id="@+id/historical_room_actions">


### PR DESCRIPTION
Dans un but de simplification les ecrans home et favoris disparaissent (pas exclu que favoris réapparaissent sous une forme ou sous une autre).
Passage en Francais de l'item de création de raccourci (il faudrait creer une string).
Enfin, puisque pour l'instant les communautés ne sont pas integrées, nous gardons l'icone groupe tel qu'il etait avant.