### PR TITLE
Retrait temporaire des alertes sur l'encryption

### DIFF
--- a/vector/src/main/java/im/vector/adapters/VectorMessagesAdapter.java
+++ b/vector/src/main/java/im/vector/adapters/VectorMessagesAdapter.java
@@ -2051,10 +2051,12 @@ public class VectorMessagesAdapter extends AbstractMessagesAdapter {
                             } else if (deviceInfo.isBlocked()) {
                                 e2eIconByEventId.put(event.eventId, R.drawable.e2e_blocked);
                             } else {
-                                e2eIconByEventId.put(event.eventId, R.drawable.e2e_warning);
+                                //don't alert the user
+                                e2eIconByEventId.put(event.eventId, R.drawable.e2e_verified);
                             }
                         } else {
-                            e2eIconByEventId.put(event.eventId, R.drawable.e2e_warning);
+                            //don't alert the user
+                            e2eIconByEventId.put(event.eventId, R.drawable.e2e_verified);
                         }
                     }
                 }

--- a/vector/src/main/java/im/vector/fragments/VectorRoomSettingsFragment.java
+++ b/vector/src/main/java/im/vector/fragments/VectorRoomSettingsFragment.java
@@ -1914,6 +1914,36 @@ public class VectorRoomSettingsFragment extends PreferenceFragment implements Sh
                         boolean newValue = (boolean) newValueAsVoid;
 
                         if (newValue != mRoom.isEncrypted()) {
+                            // hide warning for e2e
+                            displayLoadingView();
+                            mRoom.enableEncryptionWithAlgorithm(MXCryptoAlgorithms.MXCRYPTO_ALGORITHM_MEGOLM, new ApiCallback<Void>() {
+
+                                private void onDone() {
+                                    hideLoadingView(false);
+                                    refreshEndToEnd();
+                                }
+
+                                @Override
+                                public void onSuccess(Void info) {
+                                    onDone();
+                                }
+
+                                @Override
+                                public void onNetworkError(Exception e) {
+                                    onDone();
+                                }
+
+                                @Override
+                                public void onMatrixError(MatrixError e) {
+                                    onDone();
+                                }
+
+                                @Override
+                                public void onUnexpectedError(Exception e) {
+                                    onDone();
+                                }
+                            });
+                            /*
                             new AlertDialog.Builder(getActivity())
                                     .setTitle(R.string.room_settings_addresses_e2e_prompt_title)
                                     .setMessage(R.string.room_settings_addresses_e2e_prompt_message)
@@ -1962,6 +1992,7 @@ public class VectorRoomSettingsFragment extends PreferenceFragment implements Sh
                                     })
                                     .create()
                                     .show();
+                                    */
                         }
                         return true;
                     }


### PR DESCRIPTION
L'encryption est indispensable ds tchap. Cependant nous souhaitons modifier l'ux et ameliorer la gestion des devices (on ne sait pas encore comment). En attendant, pour pouvoir proposer l'encryption sans perturber l'utilisateur non averti, l'idee est de mettre les alertes en sourdine, quitte à valider automatiquement les devices inconnus.