### PR TITLE
Dinsic localcontact

### DIFF
--- a/vector/src/main/java/im/vector/activity/CommonActivityUtils.java
+++ b/vector/src/main/java/im/vector/activity/CommonActivityUtils.java
@@ -66,8 +66,6 @@ import org.matrix.androidsdk.crypto.data.MXUsersDevicesMap;
 import org.matrix.androidsdk.data.Room;
 import org.matrix.androidsdk.data.RoomPreviewData;
 import org.matrix.androidsdk.data.RoomSummary;
-import org.matrix.androidsdk.data.RoomTag;
-import org.matrix.androidsdk.data.store.IMXStore;
 import org.matrix.androidsdk.db.MXMediasCache;
 import org.matrix.androidsdk.rest.callback.ApiCallback;
 import org.matrix.androidsdk.rest.callback.SimpleApiCallback;
@@ -90,7 +88,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import im.vector.Matrix;
 import im.vector.MyPresenceManager;
@@ -1210,71 +1207,6 @@ public class CommonActivityUtils {
                                    }
         );
     }
-
-    /**
-     * Return the direct room that the searched user and the current
-     * logged user have joined. Works if the searched user is invited
-     * @param aSession        session
-     * @param aSearchedUserId the searched user ID
-     * @return  room , null otherwise
-     */
-
-
-    public static Room findDirectRoom(final MXSession aSession, final String aSearchedUserId) {
-        Room retour = null;
-        List<String> roomIds = aSession.getDirectChatRoomIdsList(aSearchedUserId);
-        List<Room> rooms = getDirectChatRooms(aSession);//(aSearchedUserId);
-        for (Room room : rooms) {
-            //Room room = aSession.getDataHandler().getRoom(roomId);
-            if (null != room) {
-                int sizeMember = room.getMembers().size();
-                int sizeInvite = room.getLiveState().thirdPartyInvites().size();
-                int mySize =  sizeMember+sizeInvite;
-                if (mySize == CommonActivityUtils.ROOM_SIZE_ONE_TO_ONE ) {
-                    if (room.getMember(aSearchedUserId)!=null)
-                        retour = room;
-                    else if (roomIds.contains(room.getRoomId()))
-                        retour = room;
-                }
-            }
-        }
-        return retour;
-
-    }
-
-    /**
-     * Return direct chat rooms
-     */
-    private static List<Room> getDirectChatRooms(final MXSession aSession) {
-        List<Room> directChats = new ArrayList<>();
-        if ((null == aSession) || (null == aSession.getDataHandler())) {
-            Log.e(LOG_TAG, "## getDirectChatRooms() : null session");
-        }
-
-        final List<String> directChatIds = aSession.getDirectChatRoomIdsList();
-        final MXDataHandler dataHandler = aSession.getDataHandler();
-        final IMXStore store = dataHandler.getStore();
-
-        if (directChatIds != null && !directChatIds.isEmpty()) {
-            for (String roomId : directChatIds) {
-                Room room = store.getRoom(roomId);
-
-                if ((null != room) && !room.isConferenceUserRoom()) {
-                    // it seems that the server syncs some left rooms
-                    if (null == room.getMember(aSession.getMyUserId())) {
-                        Log.e(LOG_TAG, "## getDirectChatRooms(): invalid room " + room.getRoomId() + ", the user is not anymore member of it");
-                    } else {
-                        final Set<String> tags = room.getAccountData().getKeys();
-                        if ((null == tags) || !tags.contains(RoomTag.ROOM_TAG_LOW_PRIORITY)) {
-                            directChats.add(dataHandler.getRoom(roomId));
-                        }
-                    }
-                }
-            }
-        }
-        return directChats;
-    }
-
 
     //==============================================================================================================
     // 1:1 Room  methods.

--- a/vector/src/main/java/im/vector/activity/CommonActivityUtils.java
+++ b/vector/src/main/java/im/vector/activity/CommonActivityUtils.java
@@ -66,6 +66,8 @@ import org.matrix.androidsdk.crypto.data.MXUsersDevicesMap;
 import org.matrix.androidsdk.data.Room;
 import org.matrix.androidsdk.data.RoomPreviewData;
 import org.matrix.androidsdk.data.RoomSummary;
+import org.matrix.androidsdk.data.RoomTag;
+import org.matrix.androidsdk.data.store.IMXStore;
 import org.matrix.androidsdk.db.MXMediasCache;
 import org.matrix.androidsdk.rest.callback.ApiCallback;
 import org.matrix.androidsdk.rest.callback.SimpleApiCallback;
@@ -88,6 +90,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import im.vector.Matrix;
 import im.vector.MyPresenceManager;
@@ -1207,6 +1210,71 @@ public class CommonActivityUtils {
                                    }
         );
     }
+
+    /**
+     * Return the direct room that the searched user and the current
+     * logged user have joined. Works if the searched user is invited
+     * @param aSession        session
+     * @param aSearchedUserId the searched user ID
+     * @return  room , null otherwise
+     */
+
+
+    public static Room findDirectRoom(final MXSession aSession, final String aSearchedUserId) {
+        Room retour = null;
+        List<String> roomIds = aSession.getDirectChatRoomIdsList(aSearchedUserId);
+        List<Room> rooms = getDirectChatRooms(aSession);//(aSearchedUserId);
+        for (Room room : rooms) {
+            //Room room = aSession.getDataHandler().getRoom(roomId);
+            if (null != room) {
+                int sizeMember = room.getMembers().size();
+                int sizeInvite = room.getLiveState().thirdPartyInvites().size();
+                int mySize =  sizeMember+sizeInvite;
+                if (mySize == CommonActivityUtils.ROOM_SIZE_ONE_TO_ONE ) {
+                    if (room.getMember(aSearchedUserId)!=null)
+                        retour = room;
+                    else if (roomIds.contains(room.getRoomId()))
+                        retour = room;
+                }
+            }
+        }
+        return retour;
+
+    }
+
+    /**
+     * Return direct chat rooms
+     */
+    private static List<Room> getDirectChatRooms(final MXSession aSession) {
+        List<Room> directChats = new ArrayList<>();
+        if ((null == aSession) || (null == aSession.getDataHandler())) {
+            Log.e(LOG_TAG, "## getDirectChatRooms() : null session");
+        }
+
+        final List<String> directChatIds = aSession.getDirectChatRoomIdsList();
+        final MXDataHandler dataHandler = aSession.getDataHandler();
+        final IMXStore store = dataHandler.getStore();
+
+        if (directChatIds != null && !directChatIds.isEmpty()) {
+            for (String roomId : directChatIds) {
+                Room room = store.getRoom(roomId);
+
+                if ((null != room) && !room.isConferenceUserRoom()) {
+                    // it seems that the server syncs some left rooms
+                    if (null == room.getMember(aSession.getMyUserId())) {
+                        Log.e(LOG_TAG, "## getDirectChatRooms(): invalid room " + room.getRoomId() + ", the user is not anymore member of it");
+                    } else {
+                        final Set<String> tags = room.getAccountData().getKeys();
+                        if ((null == tags) || !tags.contains(RoomTag.ROOM_TAG_LOW_PRIORITY)) {
+                            directChats.add(dataHandler.getRoom(roomId));
+                        }
+                    }
+                }
+            }
+        }
+        return directChats;
+    }
+
 
     //==============================================================================================================
     // 1:1 Room  methods.

--- a/vector/src/main/java/im/vector/activity/LoginActivity.java
+++ b/vector/src/main/java/im/vector/activity/LoginActivity.java
@@ -84,6 +84,7 @@ import im.vector.UnrecognizedCertHandler;
 import im.vector.receiver.VectorRegistrationReceiver;
 import im.vector.receiver.VectorUniversalLinkReceiver;
 import im.vector.services.EventStreamService;
+import im.vector.util.DinsicUtils;
 import im.vector.util.PhoneNumberUtils;
 
 /**
@@ -2166,7 +2167,6 @@ public class LoginActivity extends MXCActionBarActivity implements RegistrationM
     private ThirdPidRestClient mAgentBubbleThirdPidRestClient;
     //private ThirdPidRestClient mInternalSecuredThirdPidRestClient;
 
-    public static final String AGENT_OR_INTERNAL_SECURED_EMAIL_HOST = "gouv.fr";
 
 
     /**
@@ -2205,7 +2205,7 @@ public class LoginActivity extends MXCActionBarActivity implements RegistrationM
 
         ThirdPidRestClient thirdPartyRestClient;
 
-        if (emailAddress.endsWith(AGENT_OR_INTERNAL_SECURED_EMAIL_HOST)) {
+        if (emailAddress.endsWith(DinsicUtils.AGENT_OR_INTERNAL_SECURED_EMAIL_HOST)) {
             thirdPartyRestClient = mAgentBubbleThirdPidRestClient;
             mHSUrl = AGENT_BUBBLE_HS_URL;
             mISUrl = AGENT_BUBBLE_IS_URL;

--- a/vector/src/main/java/im/vector/activity/LoginActivity.java
+++ b/vector/src/main/java/im/vector/activity/LoginActivity.java
@@ -2166,7 +2166,7 @@ public class LoginActivity extends MXCActionBarActivity implements RegistrationM
     private ThirdPidRestClient mAgentBubbleThirdPidRestClient;
     //private ThirdPidRestClient mInternalSecuredThirdPidRestClient;
 
-    private final String AGENT_OR_INTERNAL_SECURED_EMAIL_HOST = ".gouv.fr";
+    public static final String AGENT_OR_INTERNAL_SECURED_EMAIL_HOST = "gouv.fr";
 
 
     /**

--- a/vector/src/main/java/im/vector/activity/VectorRoomCreationActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomCreationActivity.java
@@ -325,7 +325,6 @@ public class VectorRoomCreationActivity extends MXCActionBarActivity {
     public static String isDirectChatRoomAlreadyExist(String aUserId, MXSession mSession, String LOG_TAG) {
         if (null != mSession) {
             IMXStore store = mSession.getDataHandler().getStore();
-
             HashMap<String, List<String>> directChatRoomsDict;
 
             if (null != store.getDirectChatRoomsDict()) {
@@ -340,16 +339,23 @@ public class VectorRoomCreationActivity extends MXCActionBarActivity {
 
                             // check if the room is already initialized
                             if ((null != room) && room.isReady() && !room.isInvited() && !room.isLeaving()) {
-                                // test if the member did not leave the room
-                                Collection<RoomMember> members = room.getActiveMembers();
+                                //dinsic: if the member is not already in matrix and just invited he's not active but
+                                // the room can be considered as ok
+                                boolean isMatrixUserId = MXSession.PATTERN_CONTAIN_MATRIX_USER_IDENTIFIER.matcher(aUserId).matches();
+                                if (!isMatrixUserId){
+                                    return roomId;
+                                }
+                                else {
+                                    // test if the member did not leave the room
+                                    Collection<RoomMember> members = room.getActiveMembers();
 
-                                for (RoomMember member : members) {
-                                    if (TextUtils.equals(member.getUserId(), aUserId)) {
-                                        Log.d(LOG_TAG, "## isDirectChatRoomAlreadyExist(): for user=" + aUserId + " roomFound=" + roomId);
-                                        return roomId;
+                                    for (RoomMember member : members) {
+                                        if (TextUtils.equals(member.getUserId(), aUserId)) {
+                                            Log.d(LOG_TAG, "## isDirectChatRoomAlreadyExist(): for user=" + aUserId + " roomFound=" + roomId);
+                                            return roomId;
+                                        }
                                     }
                                 }
-
                             }
                         }
                     }

--- a/vector/src/main/java/im/vector/activity/VectorRoomCreationActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomCreationActivity.java
@@ -341,7 +341,7 @@ public class VectorRoomCreationActivity extends MXCActionBarActivity {
                             if ((null != room) && room.isReady() && !room.isInvited() && !room.isLeaving()) {
                                 //dinsic: if the member is not already in matrix and just invited he's not active but
                                 // the room can be considered as ok
-                                boolean isMatrixUserId = MXSession.PATTERN_CONTAIN_MATRIX_USER_IDENTIFIER.matcher(aUserId).matches();
+                                boolean isMatrixUserId = MXSession.isUserId(aUserId);
                                 if (!isMatrixUserId){
                                     return roomId;
                                 }

--- a/vector/src/main/java/im/vector/activity/VectorRoomCreationActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomCreationActivity.java
@@ -341,8 +341,7 @@ public class VectorRoomCreationActivity extends MXCActionBarActivity {
                             if ((null != room) && room.isReady() && !room.isInvited() && !room.isLeaving()) {
                                 //dinsic: if the member is not already in matrix and just invited he's not active but
                                 // the room can be considered as ok
-                                boolean isMatrixUserId = MXSession.isUserId(aUserId);
-                                if (!isMatrixUserId){
+                                if (!MXSession.isUserId(aUserId)){
                                     return roomId;
                                 }
                                 else {

--- a/vector/src/main/java/im/vector/activity/VectorRoomCreationActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomCreationActivity.java
@@ -39,6 +39,7 @@ import org.matrix.androidsdk.data.Room;
 import org.matrix.androidsdk.rest.callback.ApiCallback;
 import org.matrix.androidsdk.rest.callback.SimpleApiCallback;
 import org.matrix.androidsdk.rest.model.MatrixError;
+import org.matrix.androidsdk.MXSession;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -293,7 +294,7 @@ public class VectorRoomCreationActivity extends MXCActionBarActivity {
                     createRoom(mParticipants);
                 } else if (mParticipants.size() > 1) {
                     createRoom(mParticipants);
-                } else if (null != (existingRoomId = isDirectChatRoomAlreadyExist(mParticipants.get(0).mUserId))) {
+                } else if (null != (existingRoomId = isDirectChatRoomAlreadyExist(mParticipants.get(0).mUserId,mSession, LOG_TAG))) {
                     HashMap<String, Object> params = new HashMap<>();
                     params.put(VectorRoomActivity.EXTRA_MATRIX_ID, mParticipants.get(0).mUserId);
                     params.put(VectorRoomActivity.EXTRA_ROOM_ID, existingRoomId);
@@ -321,7 +322,7 @@ public class VectorRoomCreationActivity extends MXCActionBarActivity {
      * @param aUserId user ID to search for
      * @return a room ID if search succeed, null otherwise.
      */
-    private String isDirectChatRoomAlreadyExist(String aUserId) {
+    public static String isDirectChatRoomAlreadyExist(String aUserId, MXSession mSession, String LOG_TAG) {
         if (null != mSession) {
             IMXStore store = mSession.getDataHandler().getStore();
 

--- a/vector/src/main/java/im/vector/activity/VectorRoomInviteMembersActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomInviteMembersActivity.java
@@ -50,6 +50,7 @@ import im.vector.adapters.ParticipantAdapterItem;
 import im.vector.adapters.VectorParticipantsAdapter;
 import im.vector.contacts.Contact;
 import im.vector.contacts.ContactsManager;
+import im.vector.util.DinsicUtils;
 import im.vector.util.VectorUtils;
 import im.vector.view.VectorAutoCompleteTextView;
 
@@ -343,10 +344,9 @@ public class VectorRoomInviteMembersActivity extends VectorBaseSearchActivity {
                     }
                 } else {
                     displayNames.add(item.mUserId);
+                    if (!isStrangers) isStrangers = !DinsicUtils.isFromFrenchGov(item.mContact.getEmails());
+
                 }
-                if (!isStrangers)
-                    isStrangers = (!MXSession.PATTERN_CONTAIN_MATRIX_USER_IDENTIFIER.matcher(item.mUserId).matches() &&
-                            !ParticipantAdapterItem.isFromFrenchGov(item.mContact.getEmails()));
 
             }
         }
@@ -366,10 +366,12 @@ public class VectorRoomInviteMembersActivity extends VectorBaseSearchActivity {
 
                 message += displayNames.get(displayNames.size() - 2) + " " + getText(R.string.and) + " " + displayNames.get(displayNames.size() - 1);
             }
-            if (isStrangers)
+            if (isStrangers) {
                 builder.setMessage(getString(R.string.room_invite_non_gov_people));
-            else
+            }
+            else {
                 builder.setMessage(getString(R.string.room_participants_invite_prompt_msg, message));
+            }
             builder.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
                 @Override
                 public void onClick(DialogInterface dialog, int which) {

--- a/vector/src/main/java/im/vector/activity/VectorRoomInviteMembersActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomInviteMembersActivity.java
@@ -344,7 +344,7 @@ public class VectorRoomInviteMembersActivity extends VectorBaseSearchActivity {
                     }
                 } else {
                     displayNames.add(item.mUserId);
-                    if (!isStrangers) isStrangers = !DinsicUtils.isFromFrenchGov(item.mContact.getEmails());
+                    isStrangers |= !DinsicUtils.isFromFrenchGov(item.mContact.getEmails());
 
                 }
 

--- a/vector/src/main/java/im/vector/activity/VectorRoomInviteMembersActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomInviteMembersActivity.java
@@ -327,6 +327,7 @@ public class VectorRoomInviteMembersActivity extends VectorBaseSearchActivity {
             }
         }
 
+        boolean isStrangers = false;
         // build the output lists
         for (ParticipantAdapterItem item : participantAdapterItems) {
             // check if the user id can be added
@@ -343,11 +344,14 @@ public class VectorRoomInviteMembersActivity extends VectorBaseSearchActivity {
                 } else {
                     displayNames.add(item.mUserId);
                 }
+                if (!isStrangers)
+                    isStrangers = (!MXSession.PATTERN_CONTAIN_MATRIX_USER_IDENTIFIER.matcher(item.mUserId).matches() &&
+                            !ParticipantAdapterItem.isFromFrenchGov(item.mContact.getEmails()));
+
             }
         }
-
         // a confirmation dialog has been requested
-        if (mAddConfirmationDialog && (displayNames.size() > 0)) {
+        if ((isStrangers || mAddConfirmationDialog) && (displayNames.size() > 0)) {
             android.support.v7.app.AlertDialog.Builder builder = new android.support.v7.app.AlertDialog.Builder(VectorRoomInviteMembersActivity.this);
             builder.setTitle(R.string.dialog_title_confirmation);
 
@@ -362,8 +366,10 @@ public class VectorRoomInviteMembersActivity extends VectorBaseSearchActivity {
 
                 message += displayNames.get(displayNames.size() - 2) + " " + getText(R.string.and) + " " + displayNames.get(displayNames.size() - 1);
             }
-
-            builder.setMessage(getString(R.string.room_participants_invite_prompt_msg, message));
+            if (isStrangers)
+                builder.setMessage(getString(R.string.room_invite_non_gov_people));
+            else
+                builder.setMessage(getString(R.string.room_participants_invite_prompt_msg, message));
             builder.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
                 @Override
                 public void onClick(DialogInterface dialog, int which) {

--- a/vector/src/main/java/im/vector/adapters/ParticipantAdapterItem.java
+++ b/vector/src/main/java/im/vector/adapters/ParticipantAdapterItem.java
@@ -39,6 +39,7 @@ import im.vector.VectorApp;
 import im.vector.contacts.Contact;
 import im.vector.contacts.PIDsRetriever;
 import im.vector.util.VectorUtils;
+import im.vector.activity.LoginActivity;
 
 // Class representing a room participant.
 public class ParticipantAdapterItem implements java.io.Serializable {
@@ -177,6 +178,36 @@ public class ParticipantAdapterItem implements java.io.Serializable {
             } else if (rhs == null) {
                 return 1;
             }
+
+            return String.CASE_INSENSITIVE_ORDER.compare(lhs, rhs);
+        }
+    };
+
+    /**
+     * Get a comparator to sort members, first matrix and gouv.fr, then alphabetically
+     *
+     * @param session
+     * @return
+     */
+    public static final Comparator<ParticipantAdapterItem> alphaGouvComparator = new Comparator<ParticipantAdapterItem>() {
+        @Override
+        public int compare(ParticipantAdapterItem part1, ParticipantAdapterItem part2) {
+            String lhs = part1.getComparisonDisplayName();
+            String rhs = part2.getComparisonDisplayName();
+
+            if (lhs == null) {
+                return -1;
+            } else if (rhs == null) {
+                return 1;
+            }
+            //JP fct1 take into account the priority factor
+
+
+            if (part1.isViewedInPriority() && !part2.isViewedInPriority())
+                return -1;
+            else if (!part1.isViewedInPriority() && part2.isViewedInPriority())
+                return +1;
+            //---
 
             return String.CASE_INSENSITIVE_ORDER.compare(lhs, rhs);
         }
@@ -511,4 +542,47 @@ public class ParticipantAdapterItem implements java.io.Serializable {
 
         return !android.util.Patterns.EMAIL_ADDRESS.matcher(email).matches();
     }
+
+    /**
+     * Tells if an email is from gov
+     *
+     * @param email the email address to test.
+     * @return true if the email address is from gov
+     */
+    public  static boolean isFromFrenchGov(final String email) {
+        return email.toLowerCase().endsWith (LoginActivity.AGENT_OR_INTERNAL_SECURED_EMAIL_HOST);
+    }
+
+    /**
+     * Tells if one of the email of the list  is from gov
+     *
+     * @param emails list to test.
+     * @return true if one is from gov
+     */
+    public  static boolean isFromFrenchGov(final List<String> emails) {
+        boolean retour=false;
+        for (String myEmail : emails){
+          if (!retour) retour = isFromFrenchGov(myEmail);
+        }
+        return retour;
+    }
+    /**
+     * Tells if a participant is to be viewed in priority
+     * priority is for Matrix member and gouv member.
+     * @param
+     * @return true if matrix user or email address is from gov
+     */
+    public boolean isViewedInPriority() {
+        boolean retour = false;
+        boolean isMatrixUserId = MXSession.PATTERN_CONTAIN_MATRIX_USER_IDENTIFIER.matcher(mUserId).matches();
+
+        if (isMatrixUserId)
+            retour = true;
+        else{
+            if ((mContact!= null) && (mContact.getEmails().size()>0))
+                retour = isFromFrenchGov(mContact.getEmails());
+        }
+        return retour;
+    }
+
 }

--- a/vector/src/main/java/im/vector/adapters/ParticipantAdapterItem.java
+++ b/vector/src/main/java/im/vector/adapters/ParticipantAdapterItem.java
@@ -39,7 +39,7 @@ import im.vector.VectorApp;
 import im.vector.contacts.Contact;
 import im.vector.contacts.PIDsRetriever;
 import im.vector.util.VectorUtils;
-import im.vector.activity.LoginActivity;
+import im.vector.util.DinsicUtils;
 
 // Class representing a room participant.
 public class ParticipantAdapterItem implements java.io.Serializable {
@@ -544,29 +544,6 @@ public class ParticipantAdapterItem implements java.io.Serializable {
     }
 
     /**
-     * Tells if an email is from gov
-     *
-     * @param email the email address to test.
-     * @return true if the email address is from gov
-     */
-    public  static boolean isFromFrenchGov(final String email) {
-        return email.toLowerCase().endsWith (LoginActivity.AGENT_OR_INTERNAL_SECURED_EMAIL_HOST);
-    }
-
-    /**
-     * Tells if one of the email of the list  is from gov
-     *
-     * @param emails list to test.
-     * @return true if one is from gov
-     */
-    public  static boolean isFromFrenchGov(final List<String> emails) {
-        boolean retour=false;
-        for (String myEmail : emails){
-          if (!retour) retour = isFromFrenchGov(myEmail);
-        }
-        return retour;
-    }
-    /**
      * Tells if a participant is to be viewed in priority
      * priority is for Matrix member and gouv member.
      * @param
@@ -580,7 +557,7 @@ public class ParticipantAdapterItem implements java.io.Serializable {
             retour = true;
         else{
             if ((mContact!= null) && (mContact.getEmails().size()>0))
-                retour = isFromFrenchGov(mContact.getEmails());
+                retour = DinsicUtils.isFromFrenchGov(mContact.getEmails());
         }
         return retour;
     }

--- a/vector/src/main/java/im/vector/adapters/ParticipantAdapterItem.java
+++ b/vector/src/main/java/im/vector/adapters/ParticipantAdapterItem.java
@@ -556,8 +556,9 @@ public class ParticipantAdapterItem implements java.io.Serializable {
         if (isMatrixUserId)
             retour = true;
         else{
-            if ((mContact!= null) && (mContact.getEmails().size()>0))
+            if ((mContact!= null) && (mContact.getEmails().size()>0)) {
                 retour = DinsicUtils.isFromFrenchGov(mContact.getEmails());
+            }
         }
         return retour;
     }

--- a/vector/src/main/java/im/vector/adapters/PeopleAdapter.java
+++ b/vector/src/main/java/im/vector/adapters/PeopleAdapter.java
@@ -18,6 +18,7 @@ package im.vector.adapters;
 
 import android.content.Context;
 import android.graphics.Color;
+import android.graphics.Typeface;
 import android.support.v7.widget.RecyclerView;
 import android.text.TextUtils;
 import android.util.Pair;
@@ -80,8 +81,9 @@ public class PeopleAdapter extends AbsAdapter {
                 R.layout.adapter_item_room_view, TYPE_HEADER_DEFAULT, TYPE_ROOM, new ArrayList<Room>(), RoomUtils.getRoomsDateComparator(mSession, false));
         mDirectChatsSection.setEmptyViewPlaceholder(context.getString(R.string.no_conversation_placeholder), context.getString(R.string.no_result_placeholder));
 
+        // use the gouv comparator to show in priority matrix and agent users
         mLocalContactsSection = new AdapterSection<>(context, context.getString(R.string.local_address_book_header),
-                R.layout.adapter_local_contacts_sticky_header_subview, R.layout.adapter_item_contact_view, TYPE_HEADER_LOCAL_CONTACTS, TYPE_CONTACT, new ArrayList<ParticipantAdapterItem>(), ParticipantAdapterItem.alphaComparator);
+                R.layout.adapter_local_contacts_sticky_header_subview, R.layout.adapter_item_contact_view, TYPE_HEADER_LOCAL_CONTACTS, TYPE_CONTACT, new ArrayList<ParticipantAdapterItem>(), ParticipantAdapterItem.alphaGouvComparator);
         mLocalContactsSection.setEmptyViewPlaceholder(!ContactsManager.getInstance().isContactBookAccessAllowed() ? mNoContactAccessPlaceholder : mNoResultPlaceholder);
 
         mKnownContactsSection = new KnownContactsAdapterSection(context, context.getString(R.string.user_directory_header), -1,
@@ -350,6 +352,17 @@ public class PeopleAdapter extends AbsAdapter {
             if (position >= getItemCount()) {
                 Log.e(LOG_TAG, "## populateViews() : position out of bound " + position + " / " + getItemCount());
                 return;
+            }
+
+            // show the partipant different depending on priority
+            if (!participant.isViewedInPriority()){
+                final int semiTransparentGrey = Color.argb(155, 185, 185, 185);
+                vContactAvatar.setColorFilter(semiTransparentGrey);
+                vContactName.setTypeface(null, Typeface.ITALIC);
+            }
+            else{
+                vContactAvatar.clearColorFilter();
+                vContactName.setTypeface(null, Typeface.BOLD);
             }
 
             participant.displayAvatar(mSession, vContactAvatar);

--- a/vector/src/main/java/im/vector/adapters/VectorParticipantsAdapter.java
+++ b/vector/src/main/java/im/vector/adapters/VectorParticipantsAdapter.java
@@ -62,6 +62,7 @@ import im.vector.activity.CommonActivityUtils;
 import im.vector.contacts.Contact;
 import im.vector.contacts.ContactsManager;
 import im.vector.contacts.PIDsRetriever;
+import im.vector.util.DinsicUtils;
 import im.vector.util.VectorUtils;
 
 /**
@@ -258,7 +259,7 @@ public class VectorParticipantsAdapter extends BaseExpandableListAdapter {
                             } else {
                                 participant.mUserId = email;
                             }
-                            if (ParticipantAdapterItem.isFromFrenchGov(email)) {
+                            if (DinsicUtils.isFromFrenchGov(email)) {
                                 findGovEmail = true;
                                 if (mUsedMemberUserIds != null && !mUsedMemberUserIds.contains(participant.mUserId)) {
                                     list.add(participant);

--- a/vector/src/main/java/im/vector/fragments/PeopleFragment.java
+++ b/vector/src/main/java/im/vector/fragments/PeopleFragment.java
@@ -16,7 +16,8 @@
 
 package im.vector.fragments;
 
-import android.content.Intent;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.os.AsyncTask;
@@ -37,6 +38,7 @@ import android.widget.CompoundButton;
 import android.widget.Filter;
 
 import org.matrix.androidsdk.MXDataHandler;
+import org.matrix.androidsdk.MXSession;
 import org.matrix.androidsdk.data.Room;
 import org.matrix.androidsdk.data.RoomTag;
 import org.matrix.androidsdk.data.store.IMXStore;
@@ -50,6 +52,7 @@ import org.matrix.androidsdk.util.Log;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -57,7 +60,8 @@ import java.util.Set;
 import butterknife.BindView;
 import im.vector.R;
 import im.vector.activity.CommonActivityUtils;
-import im.vector.activity.VectorMemberDetailsActivity;
+import im.vector.activity.VectorRoomActivity;
+import im.vector.activity.VectorRoomCreationActivity;
 import im.vector.adapters.ParticipantAdapterItem;
 import im.vector.adapters.PeopleAdapter;
 import im.vector.contacts.Contact;
@@ -459,21 +463,104 @@ public class PeopleFragment extends AbsHomeFragment implements ContactsManager.C
      */
     private void onContactSelected(final ParticipantAdapterItem item) {
         if (item.mIsValid) {
-            Intent startRoomInfoIntent = new Intent(getActivity(), VectorMemberDetailsActivity.class);
-            startRoomInfoIntent.putExtra(VectorMemberDetailsActivity.EXTRA_MEMBER_ID, item.mUserId);
+            boolean isMatrixUserId = MXSession.PATTERN_CONTAIN_MATRIX_USER_IDENTIFIER.matcher(item.mUserId).matches();
+               if (isMatrixUserId || ParticipantAdapterItem.isFromFrenchGov(item.mContact.getEmails()))
+                contactSelected(item);
+            else {
+                AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getActivity());
+                alertDialogBuilder.setMessage(getString(R.string.room_invite_non_gov_people));
 
-            if (!TextUtils.isEmpty(item.mAvatarUrl)) {
-                startRoomInfoIntent.putExtra(VectorMemberDetailsActivity.EXTRA_MEMBER_AVATAR_URL, item.mAvatarUrl);
+                // set dialog message
+                alertDialogBuilder
+                        .setCancelable(false)
+                        .setPositiveButton(R.string.ok,
+                                new DialogInterface.OnClickListener() {
+                                    public void onClick(DialogInterface dialog, int id) {
+                                        contactSelected(item);
+                                    }
+                                })
+                        .setNegativeButton(R.string.cancel, null);
+
+                // create alert dialog
+                AlertDialog alertDialog = alertDialogBuilder.create();
+                // show it
+                alertDialog.show();
             }
 
-            if (!TextUtils.isEmpty(item.mDisplayName)) {
-                startRoomInfoIntent.putExtra(VectorMemberDetailsActivity.EXTRA_MEMBER_DISPLAY_NAME, item.mDisplayName);
-            }
 
-            startRoomInfoIntent.putExtra(VectorMemberDetailsActivity.EXTRA_MATRIX_ID, mSession.getCredentials().userId);
-            startActivity(startRoomInfoIntent);
+
+
+         }
+        else {// tell the user that the email must be filled. Will be improved soon
+            AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getActivity());
+            alertDialogBuilder.setMessage(getString(R.string.people_invalid_warning_msg));
+
+            // set dialog message
+            alertDialogBuilder
+                    .setCancelable(false)
+                    .setPositiveButton(R.string.ok,
+                            new DialogInterface.OnClickListener() {
+                                public void onClick(DialogInterface dialog, int id) {
+
+                                }
+                            });
+
+            // create alert dialog
+            AlertDialog alertDialog = alertDialogBuilder.create();
+            // show it
+            alertDialog.show();
+        }
+
+    }
+    /**
+     * click on a local or known contact
+     *
+     * @param item
+     */
+    private void contactSelected(final ParticipantAdapterItem item) {
+        String existingRoomId;
+        if (null != (existingRoomId = VectorRoomCreationActivity.isDirectChatRoomAlreadyExist(item.mUserId, mSession, LOG_TAG))) {
+            HashMap<String, Object> params = new HashMap<>();
+            params.put(VectorRoomActivity.EXTRA_MATRIX_ID, item.mUserId);
+            params.put(VectorRoomActivity.EXTRA_ROOM_ID, existingRoomId);
+            CommonActivityUtils.goToRoomPage(getActivity(), mSession, params);
+        } else {
+            // direct message flow
+            mSession.createDirectMessageRoom(item.mUserId, mCreateDirectMessageCallBack);
         }
     }
+
+    // direct message
+    private final ApiCallback<String> mCreateDirectMessageCallBack = new ApiCallback<String>() {
+        @Override
+        public void onSuccess(final String roomId) {
+            HashMap<String, Object> params = new HashMap<>();
+            params.put(VectorRoomActivity.EXTRA_MATRIX_ID, mSession.getMyUserId());
+            params.put(VectorRoomActivity.EXTRA_ROOM_ID, roomId);
+            params.put(VectorRoomActivity.EXTRA_EXPAND_ROOM_HEADER, true);
+
+            Log.d(LOG_TAG, "## mCreateDirectMessageCallBack: onSuccess - start goToRoomPage");
+            CommonActivityUtils.goToRoomPage(getActivity(), mSession, params);
+        }
+
+        private void onError(final String message) {
+        }
+
+        @Override
+        public void onNetworkError(Exception e) {
+            onError(e.getLocalizedMessage());
+        }
+
+        @Override
+        public void onMatrixError(final MatrixError e) {
+            onError(e.getLocalizedMessage());
+        }
+
+        @Override
+        public void onUnexpectedError(final Exception e) {
+            onError(e.getLocalizedMessage());
+        }
+    };
 
     /*
      * *********************************************************************************************
@@ -494,39 +581,55 @@ public class PeopleFragment extends AbsHomeFragment implements ContactsManager.C
 
         if (null != contacts) {
             for (Contact contact : contacts) {
-                for (String email : contact.getEmails()) {
-                    if (!TextUtils.isEmpty(email) && !ParticipantAdapterItem.isBlackedListed(email)) {
-                        Contact dummyContact = new Contact(email);
-                        dummyContact.setDisplayName(contact.getDisplayName());
-                        dummyContact.addEmailAdress(email);
-                        dummyContact.setThumbnailUri(contact.getThumbnailUri());
+                // injecter les contacts sans emails
+                //------------------------------------
+                if (contact.getEmails().size()==0){
+                    Contact dummyContact = new Contact("null");
+                    dummyContact.setDisplayName(contact.getDisplayName());
+                    dummyContact.addEmailAdress(getString(R.string.no_email));
+                    dummyContact.setThumbnailUri(contact.getThumbnailUri());
+                    //dummyContact.
 
-                        ParticipantAdapterItem participant = new ParticipantAdapterItem(dummyContact);
+                    ParticipantAdapterItem participant = new ParticipantAdapterItem(dummyContact);
 
-                        Contact.MXID mxid = PIDsRetriever.getInstance().getMXID(email);
+                    participant.mUserId = "null";
+                    participant.mIsValid = false;
+                    participants.add(participant);
 
-                        if (null != mxid) {
-                            participant.mUserId = mxid.mMatrixId;
-                        } else {
-                            participant.mUserId = email;
+
+                }
+                else {
+                    //select just one email, in priority the french gov email
+                    boolean findGovEmail = false;
+                    ParticipantAdapterItem candidatParticipant=null;
+                    for (String email : contact.getEmails()) {
+                        if (!TextUtils.isEmpty(email) && !ParticipantAdapterItem.isBlackedListed(email)) {
+                            Contact dummyContact = new Contact(email);
+                            dummyContact.setDisplayName(contact.getDisplayName());
+                            dummyContact.addEmailAdress(email);
+                            dummyContact.setThumbnailUri(contact.getThumbnailUri());
+
+                            ParticipantAdapterItem participant = new ParticipantAdapterItem(dummyContact);
+
+                            Contact.MXID mxid = PIDsRetriever.getInstance().getMXID(email);
+
+                            if (null != mxid) {
+                                participant.mUserId = mxid.mMatrixId;
+                            } else {
+                                participant.mUserId = email;
+                            }
+                            if (ParticipantAdapterItem.isFromFrenchGov(email)) {
+                                findGovEmail = true;
+                                participants.add(participant);
+                            }
+                            else if (!findGovEmail && candidatParticipant==null)
+                                candidatParticipant = participant;
                         }
-                        participants.add(participant);
                     }
+                    if (!findGovEmail && candidatParticipant!=null)
+                        participants.add(candidatParticipant);
                 }
 
-                for (Contact.PhoneNumber pn : contact.getPhonenumbers()) {
-                    Contact.MXID mxid = PIDsRetriever.getInstance().getMXID(pn.mMsisdnPhoneNumber);
-
-                    if (null != mxid) {
-                        Contact dummyContact = new Contact(pn.mMsisdnPhoneNumber);
-                        dummyContact.setDisplayName(contact.getDisplayName());
-                        dummyContact.addPhoneNumber(pn.mRawPhoneNumber, pn.mE164PhoneNumber);
-                        dummyContact.setThumbnailUri(contact.getThumbnailUri());
-                        ParticipantAdapterItem participant = new ParticipantAdapterItem(dummyContact);
-                        participant.mUserId = mxid.mMatrixId;
-                        participants.add(participant);
-                    }
-                }
             }
         }
 

--- a/vector/src/main/java/im/vector/fragments/PeopleFragment.java
+++ b/vector/src/main/java/im/vector/fragments/PeopleFragment.java
@@ -465,26 +465,33 @@ public class PeopleFragment extends AbsHomeFragment implements ContactsManager.C
         if (item.mIsValid) {
             boolean isMatrixUserId = MXSession.PATTERN_CONTAIN_MATRIX_USER_IDENTIFIER.matcher(item.mUserId).matches();
                if (isMatrixUserId || ParticipantAdapterItem.isFromFrenchGov(item.mContact.getEmails()))
-                contactSelected(item);
+                contactSelected(item, null);
             else {
-                AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getActivity());
-                alertDialogBuilder.setMessage(getString(R.string.room_invite_non_gov_people));
+                //don't have to ask the question if a room already exists
+                String existingRoomId;
+                if (null != (existingRoomId = VectorRoomCreationActivity.isDirectChatRoomAlreadyExist(item.mUserId, mSession, LOG_TAG))) {
+                    contactSelected(item,existingRoomId);
+                }
+                else {
+                    AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getActivity());
+                    alertDialogBuilder.setMessage(getString(R.string.room_invite_non_gov_people));
 
-                // set dialog message
-                alertDialogBuilder
-                        .setCancelable(false)
-                        .setPositiveButton(R.string.ok,
-                                new DialogInterface.OnClickListener() {
-                                    public void onClick(DialogInterface dialog, int id) {
-                                        contactSelected(item);
-                                    }
-                                })
-                        .setNegativeButton(R.string.cancel, null);
+                    // set dialog message
+                    alertDialogBuilder
+                            .setCancelable(false)
+                            .setPositiveButton(R.string.ok,
+                                    new DialogInterface.OnClickListener() {
+                                        public void onClick(DialogInterface dialog, int id) {
+                                            contactSelected(item,null);
+                                        }
+                                    })
+                            .setNegativeButton(R.string.cancel, null);
 
-                // create alert dialog
-                AlertDialog alertDialog = alertDialogBuilder.create();
-                // show it
-                alertDialog.show();
+                    // create alert dialog
+                    AlertDialog alertDialog = alertDialogBuilder.create();
+                    // show it
+                    alertDialog.show();
+                }
             }
 
 
@@ -517,9 +524,9 @@ public class PeopleFragment extends AbsHomeFragment implements ContactsManager.C
      *
      * @param item
      */
-    private void contactSelected(final ParticipantAdapterItem item) {
-        String existingRoomId;
-        if (null != (existingRoomId = VectorRoomCreationActivity.isDirectChatRoomAlreadyExist(item.mUserId, mSession, LOG_TAG))) {
+    private void contactSelected(final ParticipantAdapterItem item, String existingRoomId) {
+        if (null == existingRoomId) existingRoomId = VectorRoomCreationActivity.isDirectChatRoomAlreadyExist(item.mUserId, mSession, LOG_TAG);
+        if (null != existingRoomId) {
             HashMap<String, Object> params = new HashMap<>();
             params.put(VectorRoomActivity.EXTRA_MATRIX_ID, item.mUserId);
             params.put(VectorRoomActivity.EXTRA_ROOM_ID, existingRoomId);

--- a/vector/src/main/java/im/vector/fragments/PeopleFragment.java
+++ b/vector/src/main/java/im/vector/fragments/PeopleFragment.java
@@ -70,6 +70,7 @@ import im.vector.contacts.PIDsRetriever;
 import im.vector.util.VectorUtils;
 import im.vector.view.EmptyViewItemDecoration;
 import im.vector.view.SimpleDividerItemDecoration;
+import im.vector.util.DinsicUtils;
 
 public class PeopleFragment extends AbsHomeFragment implements ContactsManager.ContactsManagerListener, AbsHomeFragment.OnRoomChangedListener {
     private static final String LOG_TAG = PeopleFragment.class.getSimpleName();
@@ -463,8 +464,8 @@ public class PeopleFragment extends AbsHomeFragment implements ContactsManager.C
      */
     private void onContactSelected(final ParticipantAdapterItem item) {
         if (item.mIsValid) {
-            boolean isMatrixUserId = MXSession.PATTERN_CONTAIN_MATRIX_USER_IDENTIFIER.matcher(item.mUserId).matches();
-               if (isMatrixUserId || ParticipantAdapterItem.isFromFrenchGov(item.mContact.getEmails()))
+            boolean isMatrixUserId = MXSession.isUserId(item.mUserId);
+               if (isMatrixUserId || DinsicUtils.isFromFrenchGov(item.mContact.getEmails()))
                 contactSelected(item, null);
             else {
                 //don't have to ask the question if a room already exists
@@ -625,7 +626,7 @@ public class PeopleFragment extends AbsHomeFragment implements ContactsManager.C
                             } else {
                                 participant.mUserId = email;
                             }
-                            if (ParticipantAdapterItem.isFromFrenchGov(email)) {
+                            if (DinsicUtils.isFromFrenchGov(email)) {
                                 findGovEmail = true;
                                 participants.add(participant);
                             }

--- a/vector/src/main/java/im/vector/fragments/PeopleFragment.java
+++ b/vector/src/main/java/im/vector/fragments/PeopleFragment.java
@@ -464,8 +464,8 @@ public class PeopleFragment extends AbsHomeFragment implements ContactsManager.C
      */
     private void onContactSelected(final ParticipantAdapterItem item) {
         if (item.mIsValid) {
-            boolean isMatrixUserId = MXSession.isUserId(item.mUserId);
-               if (isMatrixUserId || DinsicUtils.isFromFrenchGov(item.mContact.getEmails()))
+
+            if (MXSession.isUserId(item.mUserId) || DinsicUtils.isFromFrenchGov(item.mContact.getEmails()))
                 contactSelected(item, null);
             else {
                 //don't have to ask the question if a room already exists

--- a/vector/src/main/java/im/vector/util/DinsicUtils.java
+++ b/vector/src/main/java/im/vector/util/DinsicUtils.java
@@ -1,0 +1,36 @@
+package im.vector.util;
+
+import java.util.List;
+
+import im.vector.activity.LoginActivity;
+
+/**
+ * Created by cloud on 1/22/18.
+ */
+
+public class DinsicUtils {
+    /**
+     * Tells if an email is from gov
+     *
+     * @param email the email address to test.
+     * @return true if the email address is from gov
+     */
+    public  static boolean isFromFrenchGov(final String email) {
+        return (null != email && email.toLowerCase().endsWith (LoginActivity.AGENT_OR_INTERNAL_SECURED_EMAIL_HOST));
+    }
+
+    /**
+     * Tells if one of the email of the list  is from gov
+     *
+     * @param emails list to test.
+     * @return true if one is from gov
+     */
+    public  static boolean isFromFrenchGov(final List<String> emails) {
+        boolean myReturn=false;
+        for (String myEmail : emails){
+            if (!myReturn) myReturn = isFromFrenchGov(myEmail);
+        }
+        return myReturn;
+    }
+
+}

--- a/vector/src/main/java/im/vector/util/DinsicUtils.java
+++ b/vector/src/main/java/im/vector/util/DinsicUtils.java
@@ -9,6 +9,7 @@ import im.vector.activity.LoginActivity;
  */
 
 public class DinsicUtils {
+    public static final String AGENT_OR_INTERNAL_SECURED_EMAIL_HOST = "gouv.fr";
     /**
      * Tells if an email is from gov
      *
@@ -16,7 +17,7 @@ public class DinsicUtils {
      * @return true if the email address is from gov
      */
     public  static boolean isFromFrenchGov(final String email) {
-        return (null != email && email.toLowerCase().endsWith (LoginActivity.AGENT_OR_INTERNAL_SECURED_EMAIL_HOST));
+        return (null != email && email.toLowerCase().endsWith (AGENT_OR_INTERNAL_SECURED_EMAIL_HOST));
     }
 
     /**

--- a/vector/src/main/res/values-fr/strings.xml
+++ b/vector/src/main/res/values-fr/strings.xml
@@ -75,6 +75,7 @@ Cliquez sur exporter pour les sauvegarder avant de vous déconnecter.</string>
     <string name="no_conversation_placeholder">Aucune discussion</string>
     <string name="no_contact_access_placeholder">Vous n\'avez pas autorisé Riot à accéder à vos contacts locaux</string>
     <string name="no_result_placeholder">Aucun résultat</string>
+    <string name="no_email">Email pas disponible</string>
 
     <string name="rooms_header">Salons</string>
     <string name="rooms_directory_header">Répertoire de salons</string>
@@ -117,7 +118,7 @@ Cliquez sur exporter pour les sauvegarder avant de vous déconnecter.</string>
     <string name="auth_skip">Ignorer</string>
     <string name="auth_send_reset_email">Envoyer l\'e-mail de réinitialisation</string>
     <string name="auth_return_to_login">Retourner à l\'écran de connexion</string>
-    <string name="auth_user_id_placeholder">E-mail</string>
+    <string name="auth_user_id_placeholder">E-mail ou nom d\'utilisateur</string>
     <string name="auth_password_placeholder">Mot de passe</string>
     <string name="auth_new_password_placeholder">Nouveau mot de passe</string>
     <string name="auth_user_name_placeholder">Nom d\'utilisateur</string>
@@ -127,7 +128,7 @@ Cliquez sur exporter pour les sauvegarder avant de vous déconnecter.</string>
     <string name="auth_opt_phone_number_placeholder">Numéro de téléphone (facultatif)</string>
     <string name="auth_repeat_password_placeholder">Répéter le mot de passe</string>
     <string name="auth_repeat_new_password_placeholder">Confirmez votre nouveau mot de passe</string>
-    <string name="auth_invalid_login_param">Email et/ou mot de passe incorrect</string>
+    <string name="auth_invalid_login_param">Nom d\'utilisateur et/ou mot de passe incorrect</string>
     <string name="auth_invalid_password">Mot de passe trop court (6 min)</string>
     <string name="auth_missing_password">Mot de passe manquant</string>
     <string name="auth_missing_email">Adresse e-mail manquante</string>
@@ -230,6 +231,8 @@ Cliquez sur exporter pour les sauvegarder avant de vous déconnecter.</string>
     <string name="people_search_filter_text">Utilisateurs Matrix uniquement</string>
     <string name="people_search_invite_by_id_dialog_title">Inviter un utilisateur par identifiant</string>
     <string name="people_search_invite_by_id_dialog_hint">E-mail ou ID Matrix</string>
+    <string name="people_invalid_warning_msg">Pour inviter un contact un email est requis</string>
+    <string name="room_invite_non_gov_people">Voulez vous vraiment inviter un partenaire exterieur dans Tchap ?</string>
 
     <string name="room_menu_search">Rechercher</string>
     <string name="room_message_placeholder_encrypted">Envoyer un message chiffré…</string>
@@ -471,7 +474,7 @@ Cliquez sur exporter pour les sauvegarder avant de vous déconnecter.</string>
     <string name="send_bug_report_failed">L\'envoi du rapport d\'erreur a échoué (%s)</string>
     <string name="auth_add_email_message">Ajoutez une adresse e-mail à votre compte pour permettre aux utilisateurs de vous retrouver et pour pouvoir réinitialiser votre mot de passe.</string>
     <string name="auth_add_phone_message">Ajoutez un numéro de téléphone à votre compte pour permettre aux utilisateurs de vous retrouver.</string>
-    <string name="auth_add_email_phone_message">Ajoutez une adresse e-mail à votre compte pour permettre aux utilisateurs de vous retrouver.
+    <string name="auth_add_email_phone_message">Ajoutez une adresse e-mail et / ou un numéro de téléphone à votre compte pour permettre aux utilisateurs de vous retrouver.
 
 L\'adresse e-mail vous permettra également de réinitialiser votre mot de passe.</string>
     <string name="auth_add_email_and_phone_message">Ajoutez une adresse e-mail et un numéro de téléphone à votre compte pour permettre aux utilisateurs de vous retrouver.

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -104,6 +104,7 @@
     <string name="no_conversation_placeholder">No conversations</string>
     <string name="no_contact_access_placeholder">You didn\'t allow Riot to access your local contacts</string>
     <string name="no_result_placeholder">No results</string>
+    <string name="no_email">Email unknown</string>
 
     <!-- Rooms fragment -->
     <string name="rooms_header">Rooms</string>
@@ -379,6 +380,8 @@
     <string name="people_search_invite_by_id_dialog_title">Invite user by ID</string>
     <string name="people_search_invite_by_id_dialog_description">Please enter one or more email address or Matrix ID</string>
     <string name="people_search_invite_by_id_dialog_hint">Email or Matrix ID</string>
+    <string name="people_invalid_warning_msg">Email required to invite a contact</string>
+    <string name="room_invite_non_gov_people">Do you really want to make him enter on Tchap ? </string>
 
     <!--  Chat -->
     <string name="room_menu_search">Search</string>


### PR DESCRIPTION
Quelques modifications liées à l'affichage des contacts locaux:
Les contacts sans emails sont quand même montrés mais on ne peut pas les inviter (l'idée ds les sprints à venir c'est de pouvoir completer à la volée l'email et/ou d'inviter par sms. D'ne maniere général on cherche à augmenter la viralité)
Lorsqu'on invite un externe non encore enrolé il y a un msg d'avertissement (car il y a une certaine responsabilité àprendre)
L'ordre d'affichage des contacts locaux est modifié: d'abord les contacts matrix et les contacts en gouv.fr, ensuite les autres, qui apparaissent en grisé (dans une logique telegram)
Une modification dans la recherche d'une direct room avant creation, pour ne pas recreer une room dans le cas d'un contact non encore matrix mais déja invité dans une room
