### PR TITLE
Set default values for fdroid non gcm notification mechanism

### DIFF
--- a/vector/src/main/java/im/vector/gcm/GcmRegistrationManager.java
+++ b/vector/src/main/java/im/vector/gcm/GcmRegistrationManager.java
@@ -1170,7 +1170,12 @@ public final class GcmRegistrationManager {
      * @return the sync timeout in ms.
      */
     public int getBackgroundSyncTimeOut() {
-        return getGcmSharedPreferences().getInt(PREFS_SYNC_TIMEOUT, 30000);
+        if ((null == mRegistrationToken) && (null == getStoredRegistrationToken()) && !getGcmSharedPreferences().contains(PREFS_SYNC_DELAY)) {
+            return getGcmSharedPreferences().getInt(PREFS_SYNC_TIMEOUT, 10000);
+        }
+        else{
+            return getGcmSharedPreferences().getInt(PREFS_SYNC_TIMEOUT, 30000);
+        }
     }
 
     /**
@@ -1190,8 +1195,9 @@ public final class GcmRegistrationManager {
     public int getBackgroundSyncDelay() {
         // on fdroid version, the default sync delay is about 10 minutes
         // set a large value because many users don't know it can be defined from the settings page
+        // for french gov deployment, defaulkt sync delay of 10s
         if ((null == mRegistrationToken) && (null == getStoredRegistrationToken()) && !getGcmSharedPreferences().contains(PREFS_SYNC_DELAY)) {
-            return 10 * 60 * 1000;
+            return  10000;
         } else {
             int currentValue = 0;
             MXSession session = Matrix.getInstance(mContext).getDefaultSession();

--- a/vector/src/main/java/im/vector/util/PreferencesManager.java
+++ b/vector/src/main/java/im/vector/util/PreferencesManager.java
@@ -489,6 +489,12 @@ public class PreferencesManager {
         // some key names have been updated to supported language switch
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
 
+        if (!preferences.contains(SETTINGS_START_ON_BOOT_PREFERENCE_KEY)) {
+            SharedPreferences.Editor editor = preferences.edit();
+            editor.putBoolean(SETTINGS_START_ON_BOOT_PREFERENCE_KEY, true);
+            editor.commit();
+        }
+
         if (preferences.contains(context.getString(R.string.settings_pin_missed_notifications))) {
             SharedPreferences.Editor editor = preferences.edit();
             editor.putBoolean(SETTINGS_PIN_MISSED_NOTIFICATIONS_PREFERENCE_KEY, preferences.getBoolean(context.getString(R.string.settings_pin_missed_notifications), false));


### PR DESCRIPTION
Fdroid non gcm notifications works well with our special secured mobile phone if we set short delays and autostart on reboot