### PR TITLE
Tchap Bug (not Riot) when you invite someone by typing his id or email

### DIFF
--- a/vector/src/main/java/im/vector/activity/VectorRoomInviteMembersActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomInviteMembersActivity.java
@@ -344,7 +344,18 @@ public class VectorRoomInviteMembersActivity extends VectorBaseSearchActivity {
                     }
                 } else {
                     displayNames.add(item.mUserId);
-                    isStrangers |= !DinsicUtils.isFromFrenchGov(item.mContact.getEmails());
+                    if (item.mContact != null && item.mContact.getEmails().size()>0)
+                        isStrangers |= !DinsicUtils.isFromFrenchGov(item.mContact.getEmails());
+                    else
+                    if (item.mUserId!= null && android.util.Patterns.EMAIL_ADDRESS.matcher(item.mUserId).matches()){
+                        List<String>myAddress = new ArrayList<>();
+                        myAddress.add(item.mUserId);
+                        isStrangers |= !DinsicUtils.isFromFrenchGov(myAddress);
+                    }
+
+
+
+
 
                 }
 


### PR DESCRIPTION
Bug on Tchap when you try to invite someone in a room by typing his id or email, the email gov verification crash (null pointer).