### PR TITLE
DINSIC : Login screen update email placeholder

### DIFF
--- a/vector/src/main/res/layout/activity_vector_login.xml
+++ b/vector/src/main/res/layout/activity_vector_login.xml
@@ -139,7 +139,7 @@
                         android:id="@+id/login_user_name"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:hint="@string/auth_user_id_placeholder"
+                        android:hint="@string/settings_email_address"
                         android:inputType="text"
                         android:maxLines="1"
                         android:nextFocusDown="@+id/login_password" />


### PR DESCRIPTION
On the login screen, the email field indicated "E-mail or username" while the username didn't work. The placeholder should only mention the email.