### PR TITLE
Handle pending invitation before creating new direct chat

### DIFF
--- a/vector/src/main/java/im/vector/activity/VectorRoomCreationActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomCreationActivity.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2015 OpenMarket Ltd
  * Copyright 2017 Vector Creations Ltd
+ * Copyright 2018 DINSIC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -313,7 +314,7 @@ public class VectorRoomCreationActivity extends MXCActionBarActivity {
      * @param aUserId user ID to search for
      * @return a room ID if search succeed, null otherwise.
      */
-    public static Room isDirectChatRoomAlreadyExist(String aUserId, MXSession mSession, boolean ignoreInvite) {
+    public static Room isDirectChatRoomAlreadyExist(String aUserId, MXSession mSession, boolean includeInvite) {
         if (null != mSession) {
             IMXStore store = mSession.getDataHandler().getStore();
             HashMap<String, List<String>> directChatRoomsDict;
@@ -331,7 +332,7 @@ public class VectorRoomCreationActivity extends MXCActionBarActivity {
                             // dinsic: if the member is not already in matrix and just invited he's not active but
                             // the room can be considered as ok
                             if ((null != room) && !room.isLeaving()) {
-                                if (!ignoreInvite || !room.isInvited()) {
+                                if (includeInvite || !room.isInvited()) {
                                     if (!MXSession.isUserId(aUserId)) {
                                         Log.d(LOG_TAG, "## isDirectChatRoomAlreadyExist(): for user=" + aUserId + " for room id=" + roomId);
                                         return room;
@@ -371,7 +372,7 @@ public class VectorRoomCreationActivity extends MXCActionBarActivity {
      * @return boolean that says if the direct chat room is open or not
      */
     private boolean isDirectChatOpened(final ParticipantAdapterItem item, boolean canCreate) {
-        Room existingRoom = this.isDirectChatRoomAlreadyExist(item.mUserId, mSession, false);
+        Room existingRoom = this.isDirectChatRoomAlreadyExist(item.mUserId, mSession, true);
         boolean succeeded = false;
 
         if (null != existingRoom) {

--- a/vector/src/main/java/im/vector/activity/VectorRoomInviteMembersActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomInviteMembersActivity.java
@@ -38,7 +38,9 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import org.matrix.androidsdk.MXSession;
+import org.matrix.androidsdk.data.Room;
 import org.matrix.androidsdk.listeners.MXEventListener;
+import org.matrix.androidsdk.rest.callback.ApiCallback;
 import org.matrix.androidsdk.rest.callback.SimpleApiCallback;
 import org.matrix.androidsdk.rest.model.Event;
 import org.matrix.androidsdk.rest.model.MatrixError;
@@ -101,6 +103,12 @@ public class VectorRoomInviteMembersActivity extends VectorBaseSearchActivity {
 
     // participants list
     private List<ParticipantAdapterItem> mHiddenParticipantItems = new ArrayList<>();
+
+    // current activity
+    VectorRoomInviteMembersActivity mActivity;
+
+    // current session
+    MXSession mxSession;
 
     // adapter
     private VectorParticipantsAdapter mAdapter;
@@ -532,7 +540,7 @@ public class VectorRoomInviteMembersActivity extends VectorBaseSearchActivity {
     private  void createNewRoom() {
         hideKeyboard();
         showWaitingView();
-        mSession.createRoom(new SimpleApiCallback<String>(VectorRoomInviteMembersActivity.this) {
+        mSession.createRoom(new SimpleApiCallback<String>(mActivity) {
             @Override
             public void onSuccess(final String roomId) {
                 mLoadingView.post(new Runnable() {
@@ -543,7 +551,7 @@ public class VectorRoomInviteMembersActivity extends VectorBaseSearchActivity {
                         params.put(VectorRoomActivity.EXTRA_MATRIX_ID, mSession.getMyUserId());
                         params.put(VectorRoomActivity.EXTRA_ROOM_ID, roomId);
                         params.put(VectorRoomActivity.EXTRA_EXPAND_ROOM_HEADER, true);
-                        CommonActivityUtils.goToRoomPage(VectorRoomInviteMembersActivity.this, mSession, params);
+                        CommonActivityUtils.goToRoomPage(mActivity, mSession, params);
                     }
                 });
             }
@@ -553,7 +561,7 @@ public class VectorRoomInviteMembersActivity extends VectorBaseSearchActivity {
                     @Override
                     public void run() {
                         if (null != message) {
-                            Toast.makeText(VectorRoomInviteMembersActivity.this, message, Toast.LENGTH_LONG).show();
+                            Toast.makeText(mActivity, message, Toast.LENGTH_LONG).show();
                         }
                         stopWaitingView();
                     }

--- a/vector/src/main/java/im/vector/activity/VectorRoomInviteMembersActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomInviteMembersActivity.java
@@ -22,25 +22,17 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.v4.app.FragmentActivity;
-import android.support.annotation.Nullable;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.view.View;
-import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.ExpandableListView;
-import android.content.Context;
-import android.widget.LinearLayout;
-import android.widget.TextView;
 import android.widget.Toast;
 
 import org.matrix.androidsdk.MXSession;
-import org.matrix.androidsdk.data.Room;
 import org.matrix.androidsdk.listeners.MXEventListener;
-import org.matrix.androidsdk.rest.callback.ApiCallback;
 import org.matrix.androidsdk.rest.callback.SimpleApiCallback;
 import org.matrix.androidsdk.rest.model.Event;
 import org.matrix.androidsdk.rest.model.MatrixError;
@@ -57,10 +49,6 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
-import butterknife.OnClick;
-import butterknife.Optional;
 import im.vector.Matrix;
 import im.vector.R;
 import im.vector.adapters.ParticipantAdapterItem;
@@ -103,12 +91,6 @@ public class VectorRoomInviteMembersActivity extends VectorBaseSearchActivity {
 
     // participants list
     private List<ParticipantAdapterItem> mHiddenParticipantItems = new ArrayList<>();
-
-    // current activity
-    VectorRoomInviteMembersActivity mActivity;
-
-    // current session
-    MXSession mxSession;
 
     // adapter
     private VectorParticipantsAdapter mAdapter;
@@ -540,7 +522,7 @@ public class VectorRoomInviteMembersActivity extends VectorBaseSearchActivity {
     private  void createNewRoom() {
         hideKeyboard();
         showWaitingView();
-        mSession.createRoom(new SimpleApiCallback<String>(mActivity) {
+        mSession.createRoom(new SimpleApiCallback<String>(VectorRoomInviteMembersActivity.this) {
             @Override
             public void onSuccess(final String roomId) {
                 mLoadingView.post(new Runnable() {
@@ -561,7 +543,7 @@ public class VectorRoomInviteMembersActivity extends VectorBaseSearchActivity {
                     @Override
                     public void run() {
                         if (null != message) {
-                            Toast.makeText(mActivity, message, Toast.LENGTH_LONG).show();
+                            Toast.makeText(VectorRoomInviteMembersActivity.this, message, Toast.LENGTH_LONG).show();
                         }
                         stopWaitingView();
                     }

--- a/vector/src/main/java/im/vector/activity/VectorRoomInviteMembersActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomInviteMembersActivity.java
@@ -551,7 +551,7 @@ public class VectorRoomInviteMembersActivity extends VectorBaseSearchActivity {
                         params.put(VectorRoomActivity.EXTRA_MATRIX_ID, mSession.getMyUserId());
                         params.put(VectorRoomActivity.EXTRA_ROOM_ID, roomId);
                         params.put(VectorRoomActivity.EXTRA_EXPAND_ROOM_HEADER, true);
-                        CommonActivityUtils.goToRoomPage(mActivity, mSession, params);
+                        CommonActivityUtils.goToRoomPage(VectorRoomInviteMembersActivity.this, mSession, params);
                     }
                 });
             }

--- a/vector/src/main/java/im/vector/fragments/ContactFragment.java
+++ b/vector/src/main/java/im/vector/fragments/ContactFragment.java
@@ -667,6 +667,7 @@ public class ContactFragment extends AbsHomeFragment implements ContactsManager.
             params.put(VectorRoomActivity.EXTRA_ROOM_ID, roomId);
             params.put(VectorRoomActivity.EXTRA_EXPAND_ROOM_HEADER, true);
 
+            Log.d(LOG_TAG, "## mCreateDirectMessageCallBack: onSuccess - start goToRoomPage");
             CommonActivityUtils.goToRoomPage(getActivity(), mSession, params);
         }
 

--- a/vector/src/main/java/im/vector/fragments/ContactFragment.java
+++ b/vector/src/main/java/im/vector/fragments/ContactFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 New Vector Ltd
+ * Copyright 2018 DINSIC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -549,7 +549,7 @@ public class ContactFragment extends AbsHomeFragment implements ContactsManager.
                 String msg = getString(R.string.room_invite_non_gov_people);
                 if (DinsicUtils.isFromFrenchGov(item.mContact.getEmails()))
                     msg = getString(R.string.room_invite_gov_people);
-                if (null != (existingRoom = VectorRoomCreationActivity.isDirectChatRoomAlreadyExist(item.mUserId, mSession, true))) {
+                if (null != (existingRoom = VectorRoomCreationActivity.isDirectChatRoomAlreadyExist(item.mUserId, mSession, false))) {
                     openDirectChat(item, false);
                 } else if (LoginActivity.isUserExternal(mSession)) {
                     DinsicUtils.alertSimpleMsg(getActivity(), getString(R.string.room_creation_forbidden));
@@ -588,7 +588,7 @@ public class ContactFragment extends AbsHomeFragment implements ContactsManager.
      * @return the corresponding room id or null
      */
     private boolean openDirectChat (final ParticipantAdapterItem item, boolean canCreate) {
-        Room existingRoom = VectorRoomCreationActivity.isDirectChatRoomAlreadyExist(item.mUserId, mSession, false);
+        Room existingRoom = VectorRoomCreationActivity.isDirectChatRoomAlreadyExist(item.mUserId, mSession, true);
         boolean directChatOpened = false;
 
         if (null != existingRoom) {

--- a/vector/src/main/java/im/vector/fragments/PeopleFragment.java
+++ b/vector/src/main/java/im/vector/fragments/PeopleFragment.java
@@ -473,9 +473,9 @@ public class PeopleFragment extends AbsHomeFragment implements ContactsManager.C
                 contactSelected(item, null);
             else {
                 //don't have to ask the question if a room already exists
-                String existingRoomId;
-                if (null != (existingRoomId = VectorRoomCreationActivity.isDirectChatRoomAlreadyExist(item.mUserId, mSession, LOG_TAG))) {
-                    contactSelected(item, existingRoomId);
+                Room existingRoom;
+                if (null != (existingRoom = VectorRoomCreationActivity.isDirectChatRoomAlreadyExist(item.mUserId, mSession, false))) {
+                    contactSelected(item, existingRoom);
                 } else {
                     AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getActivity());
                     alertDialogBuilder.setMessage(getString(R.string.room_invite_non_gov_people));
@@ -523,15 +523,15 @@ public class PeopleFragment extends AbsHomeFragment implements ContactsManager.C
      *
      * @param item
      */
-    private void contactSelected(final ParticipantAdapterItem item, String existingRoomId) {
-        if (null == existingRoomId) {
-            existingRoomId = VectorRoomCreationActivity.isDirectChatRoomAlreadyExist(item.mUserId, mSession, LOG_TAG);
+    private void contactSelected(final ParticipantAdapterItem item, Room existingRoom) {
+        if (null == existingRoom.getRoomId()) {
+            existingRoom = VectorRoomCreationActivity.isDirectChatRoomAlreadyExist(item.mUserId, mSession, true);
         }
 
-        if (null != existingRoomId) {
+        if (null != existingRoom) {
             HashMap<String, Object> params = new HashMap<>();
             params.put(VectorRoomActivity.EXTRA_MATRIX_ID, item.mUserId);
-            params.put(VectorRoomActivity.EXTRA_ROOM_ID, existingRoomId);
+            params.put(VectorRoomActivity.EXTRA_ROOM_ID, existingRoom.getRoomId());
             CommonActivityUtils.goToRoomPage(getActivity(), mSession, params);
         } else {
             // direct message flow

--- a/vector/src/main/java/im/vector/fragments/PeopleFragment.java
+++ b/vector/src/main/java/im/vector/fragments/PeopleFragment.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017 Vector Creations Ltd
+ * Copyright 2018 DINSIC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -474,7 +475,7 @@ public class PeopleFragment extends AbsHomeFragment implements ContactsManager.C
             else {
                 //don't have to ask the question if a room already exists
                 Room existingRoom;
-                if (null != (existingRoom = VectorRoomCreationActivity.isDirectChatRoomAlreadyExist(item.mUserId, mSession, true))) {
+                if (null != (existingRoom = VectorRoomCreationActivity.isDirectChatRoomAlreadyExist(item.mUserId, mSession, false))) {
                     contactSelected(item, existingRoom);
                 } else {
                     AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getActivity());
@@ -525,7 +526,7 @@ public class PeopleFragment extends AbsHomeFragment implements ContactsManager.C
      */
     private void contactSelected(final ParticipantAdapterItem item, Room existingRoom) {
         if (null == existingRoom) {
-            existingRoom = VectorRoomCreationActivity.isDirectChatRoomAlreadyExist(item.mUserId, mSession, true);
+            existingRoom = VectorRoomCreationActivity.isDirectChatRoomAlreadyExist(item.mUserId, mSession, false);
         }
 
         if (null != existingRoom) {

--- a/vector/src/main/java/im/vector/fragments/PeopleFragment.java
+++ b/vector/src/main/java/im/vector/fragments/PeopleFragment.java
@@ -474,7 +474,7 @@ public class PeopleFragment extends AbsHomeFragment implements ContactsManager.C
             else {
                 //don't have to ask the question if a room already exists
                 Room existingRoom;
-                if (null != (existingRoom = VectorRoomCreationActivity.isDirectChatRoomAlreadyExist(item.mUserId, mSession, false))) {
+                if (null != (existingRoom = VectorRoomCreationActivity.isDirectChatRoomAlreadyExist(item.mUserId, mSession, true))) {
                     contactSelected(item, existingRoom);
                 } else {
                     AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getActivity());
@@ -524,7 +524,7 @@ public class PeopleFragment extends AbsHomeFragment implements ContactsManager.C
      * @param item
      */
     private void contactSelected(final ParticipantAdapterItem item, Room existingRoom) {
-        if (null == existingRoom.getRoomId()) {
+        if (null == existingRoom) {
             existingRoom = VectorRoomCreationActivity.isDirectChatRoomAlreadyExist(item.mUserId, mSession, true);
         }
 

--- a/vector/src/main/res/layout/fragment_people.xml
+++ b/vector/src/main/res/layout/fragment_people.xml
@@ -8,4 +8,19 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
+    <FrameLayout
+        android:id="@+id/listView_spinner_views"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="?attr/waiting_background_color"
+        android:visibility="gone">
+
+        <ProgressBar
+            android:id="@+id/listView_spinner"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:layout_gravity="center"
+            android:visibility="visible" />
+    </FrameLayout>
+
 </RelativeLayout>


### PR DESCRIPTION
Refers to https://github.com/dinsic-pim/riot-android/issues/44

Avoid cross invitations and creating multiple direct chats for the same 2 users
- join the room if an invitation is pending and don't create a new direct chat