### PR TITLE
Remove dependency to droidsonroids (static splash image)

### DIFF
--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -182,7 +182,7 @@ dependencies {
     implementation 'com.facebook.stetho:stetho-okhttp3:1.5.0'
     implementation 'com.squareup.okio:okio:1.13.0'
 
-    implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.+'
+    //implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.+'
 
     // Use Glide library to display image (Gif supported)
     implementation 'com.github.bumptech.glide:glide:4.7.1'

--- a/vector/src/main/res/layout/vector_activity_splash.xml
+++ b/vector/src/main/res/layout/vector_activity_splash.xml
@@ -4,6 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <!--
     <pl.droidsonroids.gif.GifImageView
         android:id="@+id/animated_logo_image_view"
         android:src="@drawable/tchap_splash"
@@ -12,13 +13,14 @@
         android:adjustViewBounds="true"
         android:scaleType="fitXY"
         android:visibility="visible"/>
+        -->
 
-    <!-- ImageView
+    <ImageView
         android:id="@+id/splash_logo_image_view"
-        android:src="@drawable/tchap_splash_logo"
+        android:src="@drawable/tchap_splash"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:adjustViewBounds="true"
         android:scaleType="fitXY"
-        android:visibility="visible"/-->
+        android:visibility="visible" />
 </RelativeLayout>


### PR DESCRIPTION
Remove dependency to droidsonroids (including a native library) to display (only) a static splash screen image.