### PR TITLE
Detect accessibility service

### DIFF
--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -100,15 +100,19 @@
 
         <!-- activities list starts here -->
         <activity
+            android:name="fr.gouv.tchap.activity.NotificationListenerDetectionActivity"
+            android:configChanges="orientation|screenSize"
+            android:theme="@style/AppTheme.NoActionBar.Swipe.Startup.Dark">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name="fr.gouv.tchap.activity.TchapLoginActivity"
             android:configChanges="orientation|screenSize"
             android:theme="@style/LoginAppTheme"
             android:windowSoftInputMode="stateHidden|adjustResize">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
         </activity>
         <activity android:name="fr.gouv.tchap.activity.TchapRoomCreationActivity"
             android:configChanges="orientation|screenSize"
@@ -130,6 +134,10 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="im.vector.activity.VectorHomeActivity" />
         </activity>
+        <activity
+            android:name="fr.gouv.tchap.activity.AccessibilityServiceDetectionActivity"
+            android:configChanges="orientation|screenSize"
+            android:theme="@style/AppTheme.NoActionBar.Swipe.Startup.Dark"/>
         <activity
             android:name=".activity.AccountCreationActivity"
             android:configChanges="orientation|screenSize"

--- a/vector/src/main/java/fr/gouv/tchap/activity/AccessibilityServiceDetectionActivity.java
+++ b/vector/src/main/java/fr/gouv/tchap/activity/AccessibilityServiceDetectionActivity.java
@@ -1,0 +1,86 @@
+package fr.gouv.tchap.activity;
+
+
+import android.content.ContentResolver;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.os.Bundle;
+import android.provider.Settings;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AlertDialog;
+import android.support.v7.app.AppCompatActivity;
+
+import org.matrix.androidsdk.util.Log;
+
+import im.vector.R;
+import im.vector.util.PreferencesManager;
+
+public class AccessibilityServiceDetectionActivity extends AppCompatActivity {
+
+    public static boolean isAccessibilityServiceActive(ContentResolver contentResolver) {
+        int accessibilityEnabled = 0;
+
+        try {
+            accessibilityEnabled = Settings.Secure.getInt(contentResolver, android.provider.Settings.Secure.ACCESSIBILITY_ENABLED);
+        } catch (android.provider.Settings.SettingNotFoundException e) {
+            Log.d("AccessibilityServiceDetectionActivity", "*** Security : accessibility settings not found ****");
+        }
+
+        return (accessibilityEnabled == 0) ? false : true;
+    }
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        if (!PreferencesManager.detectAccessibilityService(this)) {
+            finish(true);
+            return;
+        }
+
+
+        if (!isAccessibilityServiceActive(getContentResolver())) {
+            finish(true);
+            return;
+        }
+
+        new AlertDialog.Builder(this)
+                .setMessage(R.string.accessibility_security_dialog_message)
+                .setIcon(R.drawable.message_notification_transparent)
+                .setTitle(R.string.security_dialog_title)
+                .setPositiveButton(R.string.security_dialog_start, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        finish(true);
+                    }
+                })
+                .setNeutralButton(R.string.security_dialog_start_an_stop_detecting, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        PreferencesManager.putDetectAccessibilityService(AccessibilityServiceDetectionActivity.this, false);
+                        finish(true);
+                    }
+                })
+                .setNegativeButton(R.string.security_dialog_stop, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        finish(false);
+                    }
+                })
+                .setOnCancelListener(new DialogInterface.OnCancelListener() {
+                    @Override
+                    public void onCancel(DialogInterface dialog) {
+                        finish(false);
+                    }
+                })
+                .show();
+    }
+
+    private void finish(boolean startNext) {
+        finish();
+        if(startNext) {
+            Intent start = new Intent(AccessibilityServiceDetectionActivity.this, TchapLoginActivity.class);
+            startActivity(start);
+        }
+    }
+}

--- a/vector/src/main/java/fr/gouv/tchap/activity/NotificationListenerDetectionActivity.java
+++ b/vector/src/main/java/fr/gouv/tchap/activity/NotificationListenerDetectionActivity.java
@@ -1,0 +1,136 @@
+package fr.gouv.tchap.activity;
+
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+import android.provider.Settings;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AlertDialog;
+import android.support.v7.app.AppCompatActivity;
+
+import im.vector.R;
+import im.vector.util.PreferencesManager;
+
+public class NotificationListenerDetectionActivity extends AppCompatActivity {
+
+    /**
+     * Retrieves the display name of an application from its package name
+     *
+     * @param packagename the package name of the application
+     * @param context     the context used to retrieve the package manager
+     * @return the display name of the application identified by packagename, or "(unknown)" if not installed
+     */
+    public static String getAppName(String packagename, Context context) {
+        final PackageManager pm = context.getPackageManager();
+
+        ApplicationInfo ai;
+        try {
+            ai = pm.getApplicationInfo(packagename, 0);
+        } catch (final PackageManager.NameNotFoundException e) {
+            ai = null;
+        }
+        String applicationName = (String) (ai != null ? pm.getApplicationLabel(ai) : "(unknown)");
+        return applicationName;
+    }
+
+    /**
+     * Retrieves the display name of the applications which currently expose an active NotificationListener service
+     *
+     * @param context
+     * @param contentresolver
+     * @return
+     */
+    public static String[] getListeningServiceAppName(Context context, ContentResolver contentresolver) {
+        String flat = Settings.Secure.getString(contentresolver, "enabled_notification_listeners");
+
+
+        if ((flat == null) || (flat.equals(""))) return new String[]{};
+
+        String[] large_descriptions = flat.split(":");
+        String[] appname_array = new String[large_descriptions.length];
+
+        for (int i = 0; i < large_descriptions.length; i++) {
+            String[] splitted = large_descriptions[i].split("/");
+            String packagename = splitted[0];
+
+            appname_array[i] = getAppName(packagename, context);
+        }
+
+        return appname_array;
+    }
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        StringBuilder string_builder = null;
+        String message = "";
+
+        String[] notificationListenerNames = new String[]{};
+
+        if (!PreferencesManager.detectNotificationListener(this)) {
+            finish(true);
+            return;
+        }
+
+
+        notificationListenerNames = getListeningServiceAppName(getApplicationContext(), getContentResolver());
+
+        if (notificationListenerNames.length == 0) {
+            finish(true);
+            return;
+        }
+
+        string_builder = new StringBuilder();
+
+        message = getResources().getString(R.string.notification_security_dialog_message);
+
+
+        for (String s : notificationListenerNames) {
+            string_builder.append("\n").append("- ").append(s);
+        }
+
+        new AlertDialog.Builder(this)
+                .setMessage(message + string_builder.toString())
+                .setIcon(R.drawable.message_notification_transparent)
+                .setTitle(R.string.security_dialog_title)
+                .setPositiveButton(R.string.security_dialog_start, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        finish(true);
+                    }
+                })
+                .setNeutralButton(R.string.security_dialog_start_an_stop_detecting, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        PreferencesManager.putDetectNotificationListener(NotificationListenerDetectionActivity.this, false);
+                        finish(true);
+                    }
+                })
+                .setNegativeButton(R.string.security_dialog_stop, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        finish(false);
+                    }
+                })
+                .setOnCancelListener(new DialogInterface.OnCancelListener() {
+                    @Override
+                    public void onCancel(DialogInterface dialog) {
+                        finish(false);
+                    }
+                })
+                .show();
+    }
+
+    private void finish(boolean startNext) {
+        finish();
+        if (startNext) {
+            Intent start = new Intent(this, AccessibilityServiceDetectionActivity.class);
+            startActivity(start);
+        }
+    }
+}

--- a/vector/src/main/java/fr/gouv/tchap/util/LiveSecurityChecks.java
+++ b/vector/src/main/java/fr/gouv/tchap/util/LiveSecurityChecks.java
@@ -1,0 +1,135 @@
+package fr.gouv.tchap.util;
+
+import android.app.Activity;
+import android.content.DialogInterface;
+import android.support.v7.app.AlertDialog;
+
+import org.matrix.androidsdk.util.Log;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import fr.gouv.tchap.activity.AccessibilityServiceDetectionActivity;
+import fr.gouv.tchap.activity.NotificationListenerDetectionActivity;
+import im.vector.R;
+import im.vector.util.PreferencesManager;
+
+public class LiveSecurityChecks {
+
+    // security state
+    // ---------------
+    // the variable are static to be remembered from one activity to the other to avoid
+    // multiple notifications when going back from one activity to an other
+    // stopped_before_starting is true if we went through onStop,Pause,...
+    private static boolean stopped_before_starting;
+    // contains the string returned by Settings.Secure.get(... "enabled_notification_listeners")
+    private static String[] notificationListenerState_at_stop;
+    //contains the state of the accessibility service
+    private static boolean accessibilityServiceActive_at_stop;
+
+    private Activity attachedActivity;
+
+    public LiveSecurityChecks(Activity activityAttached) {
+        stopped_before_starting = false;
+        attachedActivity = activityAttached;
+    }
+
+    public void activityStopped() {
+        Log.d(LiveSecurityChecks.class.getSimpleName(), "**** activityStopped ****");
+
+        stopped_before_starting = true;
+        notificationListenerState_at_stop = NotificationListenerDetectionActivity.getListeningServiceAppName(
+                attachedActivity.getApplicationContext(),
+                attachedActivity.getContentResolver());
+        accessibilityServiceActive_at_stop = AccessibilityServiceDetectionActivity.isAccessibilityServiceActive(
+                attachedActivity.getContentResolver());
+    }
+
+    public void checkOnActivityStart() {
+        if (!stopped_before_starting)
+            return;
+
+        stopped_before_starting = false;
+
+        checkAccessibilityChange();
+        checkNotificationListenerChange();
+    }
+
+    protected void checkAccessibilityChange() {
+        if (!PreferencesManager.detectAccessibilityService(attachedActivity))
+            return;
+
+        boolean accessibilityServiceActive_at_start = AccessibilityServiceDetectionActivity.isAccessibilityServiceActive(
+                attachedActivity.getContentResolver());
+
+        if ((!accessibilityServiceActive_at_stop) && accessibilityServiceActive_at_start) {
+            new AlertDialog.Builder(attachedActivity)
+                    .setMessage(R.string.accessibility_change_security_dialog_message)
+                    .setIcon(R.drawable.message_notification_transparent)
+                    .setTitle(R.string.security_dialog_title)
+                    .setPositiveButton(R.string.security_dialog_continue, null)
+                    .setNeutralButton(R.string.security_dialog_start_an_stop_detecting, new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            PreferencesManager.putDetectAccessibilityService(LiveSecurityChecks.this.attachedActivity, false);
+                        }
+                    })
+                    .setNegativeButton(R.string.security_dialog_stop, new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            LiveSecurityChecks.this.attachedActivity.finishAffinity();
+                        }
+                    })
+                    .show();
+        }
+    }
+
+    protected void checkNotificationListenerChange() {
+        if (!PreferencesManager.detectNotificationListener(attachedActivity))
+            return;
+
+        String[] notificationListenerState_at_start = NotificationListenerDetectionActivity.getListeningServiceAppName(
+                attachedActivity.getApplicationContext(),
+                attachedActivity.getContentResolver());
+
+        ArrayList<String> newNotificationListeners = new ArrayList<String>();
+        List<String> oldNotificationListeners = Arrays.asList(notificationListenerState_at_stop);
+
+        for (String listenerAtStart : notificationListenerState_at_start) {
+            if (!oldNotificationListeners.contains(listenerAtStart))
+                newNotificationListeners.add(listenerAtStart);
+        }
+
+        if (newNotificationListeners.size() == 0)
+            return;
+
+        // notifies the user of new notification listener
+        StringBuilder notificationMessageBuilder = new StringBuilder();
+
+        for (String s : newNotificationListeners) {
+            notificationMessageBuilder.append("\n").append("- ").append(s);
+        }
+
+        String message = attachedActivity.getResources().getString(R.string.notification_security_dialog_message) +
+                notificationMessageBuilder.toString();
+
+        new AlertDialog.Builder(attachedActivity)
+                .setMessage(message)
+                .setIcon(R.drawable.message_notification_transparent)
+                .setTitle(R.string.security_dialog_title)
+                .setPositiveButton(R.string.security_dialog_continue, null)
+                .setNeutralButton(R.string.security_dialog_start_an_stop_detecting, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        PreferencesManager.putDetectNotificationListener(LiveSecurityChecks.this.attachedActivity, false);
+                    }
+                })
+                .setNegativeButton(R.string.security_dialog_stop, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        LiveSecurityChecks.this.attachedActivity.finishAffinity();
+                    }
+                }).show();
+    }
+}

--- a/vector/src/main/java/im/vector/activity/VectorHomeActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorHomeActivity.java
@@ -108,6 +108,7 @@ import butterknife.BindView;
 import fr.gouv.tchap.activity.TchapLoginActivity;
 import fr.gouv.tchap.activity.TchapRoomCreationActivity;
 import fr.gouv.tchap.activity.TchapPublicRoomSelectionActivity;
+import fr.gouv.tchap.util.LiveSecurityChecks;
 import im.vector.Matrix;
 import im.vector.MyPresenceManager;
 import im.vector.R;
@@ -250,6 +251,9 @@ public class VectorHomeActivity extends RiotAppCompatActivity implements SearchV
 
     // floating action button dialog
     private AlertDialog mFabDialog;
+
+    // security
+    private LiveSecurityChecks securityChecks = new LiveSecurityChecks(this);
 
     /*
      * *********************************************************************************************
@@ -486,6 +490,9 @@ public class VectorHomeActivity extends RiotAppCompatActivity implements SearchV
     @Override
     protected void onResume() {
         super.onResume();
+
+        securityChecks.checkOnActivityStart();
+
         MyPresenceManager.createPresenceManager(this, Matrix.getInstance(this).getSessions());
         MyPresenceManager.advertiseAllOnline();
 
@@ -772,6 +779,8 @@ public class VectorHomeActivity extends RiotAppCompatActivity implements SearchV
     protected void onPause() {
         super.onPause();
 
+        securityChecks.activityStopped();
+
         // Unregister Broadcast receiver
         hideWaitingView();
         try {
@@ -803,6 +812,8 @@ public class VectorHomeActivity extends RiotAppCompatActivity implements SearchV
     @Override
     public void onDestroy() {
         super.onDestroy();
+
+        securityChecks.activityStopped();
 
         // release the static instance if it is the current implementation
         if (sharedInstance == this) {

--- a/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
@@ -112,9 +112,11 @@ import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 
+import fr.gouv.tchap.activity.AccessibilityServiceDetectionActivity;
 import fr.gouv.tchap.activity.TchapDirectRoomDetailsActivity;
 import fr.gouv.tchap.activity.TchapLoginActivity;
 import fr.gouv.tchap.util.DinsicUtils;
+import fr.gouv.tchap.util.LiveSecurityChecks;
 import im.vector.Matrix;
 import im.vector.R;
 import im.vector.VectorApp;
@@ -304,6 +306,7 @@ public class VectorRoomActivity extends MXCActionBarActivity implements MatrixMe
         }
     };
 
+
     private String mCallId = null;
 
     // typing event management
@@ -330,6 +333,9 @@ public class VectorRoomActivity extends MXCActionBarActivity implements MatrixMe
 
     // action to do after requesting the camera permission
     private int mCameraPermissionAction;
+
+    // security
+    private LiveSecurityChecks securityChecks = new LiveSecurityChecks(this);
 
     /**
      * Presence and room preview listeners
@@ -1152,6 +1158,9 @@ public class VectorRoomActivity extends MXCActionBarActivity implements MatrixMe
 
     @Override
     public void onDestroy() {
+
+        securityChecks.activityStopped();
+
         if (null != mVectorMessageListFragment) {
             mVectorMessageListFragment.onDestroy();
         }
@@ -1170,6 +1179,8 @@ public class VectorRoomActivity extends MXCActionBarActivity implements MatrixMe
     @Override
     protected void onPause() {
         super.onPause();
+
+        securityChecks.activityStopped();
 
         if (mReadMarkerManager != null) {
             mReadMarkerManager.onPause();
@@ -1205,6 +1216,8 @@ public class VectorRoomActivity extends MXCActionBarActivity implements MatrixMe
     protected void onResume() {
         Log.d(LOG_TAG, "++ Resume the activity");
         super.onResume();
+
+        securityChecks.checkOnActivityStart();
 
         ViewedRoomTracker.getInstance().setMatrixId(mSession.getCredentials().userId);
 

--- a/vector/src/main/java/im/vector/activity/VectorRoomDetailsActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomDetailsActivity.java
@@ -43,6 +43,7 @@ import java.util.List;
 
 import butterknife.BindView;
 import fr.gouv.tchap.util.DinsicUtils;
+import fr.gouv.tchap.util.LiveSecurityChecks;
 import im.vector.Matrix;
 import im.vector.R;
 import im.vector.contacts.ContactsManager;
@@ -106,6 +107,9 @@ public class VectorRoomDetailsActivity extends MXCActionBarActivity {
 
     // request the contacts permission
     private boolean mIsContactsPermissionChecked;
+
+    // security
+    private LiveSecurityChecks securityChecks = new LiveSecurityChecks(this);
 
     private final MXEventListener mEventListener = new MXEventListener() {
         @Override
@@ -311,6 +315,8 @@ public class VectorRoomDetailsActivity extends MXCActionBarActivity {
     @Override
     protected void onResume() {
         super.onResume();
+
+        securityChecks.checkOnActivityStart();
 
         if (mSession.isAlive()) {
             // check if the room has been left from another client

--- a/vector/src/main/java/im/vector/activity/VectorSharedFilesActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorSharedFilesActivity.java
@@ -18,7 +18,6 @@
 package im.vector.activity;
 
 import android.content.Intent;
-import android.os.Bundle;
 
 import org.matrix.androidsdk.data.RoomMediaMessage;
 import org.matrix.androidsdk.util.Log;
@@ -29,6 +28,7 @@ import org.matrix.androidsdk.util.ContentUtils;
 import java.io.File;
 import java.util.ArrayList;
 
+import fr.gouv.tchap.activity.NotificationListenerDetectionActivity;
 import fr.gouv.tchap.activity.TchapLoginActivity;
 import im.vector.Matrix;
 import im.vector.R;
@@ -81,7 +81,7 @@ public class VectorSharedFilesActivity extends RiotAppCompatActivity {
                     Log.d(LOG_TAG, "onCreate : go to login screen");
 
                     // don't know what to do, go to the login screen
-                    Intent loginIntent = new Intent(this, TchapLoginActivity.class);
+                    Intent loginIntent = new Intent(this, NotificationListenerDetectionActivity.class);
                     startActivity(loginIntent);
                 }
             } else {

--- a/vector/src/main/java/im/vector/util/PreferencesManager.java
+++ b/vector/src/main/java/im/vector/util/PreferencesManager.java
@@ -143,6 +143,9 @@ public class PreferencesManager {
 
     public static final String SETTINGS_DEACTIVATE_ACCOUNT_KEY = "SETTINGS_DEACTIVATE_ACCOUNT_KEY";
 
+    public static final String SETTINGS_DETECT_ACCESSIBILITY_SERVICE_KEY = "SETTINGS_DETECT_ACCESSIBILITY_SERVICE_KEY";
+    public static final String SETTINGS_DETECT_NOTIFICATION_LISTENER_KEY = "SETTINGS_DETECT_NOTIFICATION_LISTENER_KEY";
+
     private static final int MEDIA_SAVING_3_DAYS = 0;
     private static final int MEDIA_SAVING_1_WEEK = 1;
     private static final int MEDIA_SAVING_1_MONTH = 2;
@@ -211,6 +214,36 @@ public class PreferencesManager {
         }
 
         editor.apply();
+    }
+
+    /**
+     * Tells if we want to check at each start up if some notification listener(s) is active
+     *
+     */
+    public static boolean detectNotificationListener(Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(SETTINGS_DETECT_NOTIFICATION_LISTENER_KEY, true);
+    }
+
+    public static void putDetectNotificationListener(Context context, boolean asked) {
+        PreferenceManager.getDefaultSharedPreferences(context)
+                .edit()
+                .putBoolean(SETTINGS_DETECT_NOTIFICATION_LISTENER_KEY, asked)
+                .apply();
+    }
+
+    /**
+     * Tells if we want to check at each start up if an accessibility service is active
+     *
+     */
+    public static boolean detectAccessibilityService(Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(SETTINGS_DETECT_ACCESSIBILITY_SERVICE_KEY, true);
+    }
+
+    public static void putDetectAccessibilityService(Context context, boolean asked) {
+        PreferenceManager.getDefaultSharedPreferences(context)
+                .edit()
+                .putBoolean(SETTINGS_DETECT_ACCESSIBILITY_SERVICE_KEY, asked)
+                .apply();
     }
 
     /**

--- a/vector/src/main/res/values-fr/strings.xml
+++ b/vector/src/main/res/values-fr/strings.xml
@@ -1038,4 +1038,16 @@ La visibilité des messages dans Matrix est identique à celle des e-mails. Si n
     <string name="tab_rooms_title">CONVERSATIONS</string>
     <string name="tab_contacts_title">CONTACTS</string>
 
+    <!-- accessibility -->
+    <string name="security_dialog_title">Sécurité</string>
+    <string name="detect_accessibility_service">Détecter si un service d\'accessibilité est actif.</string>
+    <string name="accessibility_security_dialog_message">Un service d\'accessibilité est actif. Il observe le clavier et les fenêtres.</string>
+    <string name="security_dialog_start">Démarrer quand même.</string>
+    <string name="security_dialog_start_an_stop_detecting">Ne plus me prévenir.</string>
+    <string name="security_dialog_stop">Sortir.</string>
+    <string name="detect_notification_listener">Détecter si un écouteur de notification est actif.</string>
+    <string name="notification_security_dialog_message">Un écouteur de notification lit le contenu des notifications de message. Les écouteurs suivant sont activés :</string>
+    <string name="security_dialog_continue">Continuer.</string>
+    <string name="accessibility_change_security_dialog_message">Un service d\'accessibilité a été activé. Il observe le clavier et les fenêtres.</string>
+    <string name="notification_change_security_dialog_message">Un écouteur de notification lit le contenu des notifications de message. Les écouteurs suivant ont été activés :</string>
 </resources>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -1049,4 +1049,16 @@
     <string name="tab_rooms_title">ROOMS</string>
     <string name="tab_contacts_title">CONTACTS</string>
 
+    <!--security -->
+    <string name="security_dialog_title">Security</string>
+    <string name="detect_accessibility_service">Detect if an accessibility service is active.</string>
+    <string name="accessibility_security_dialog_message">An accessibility service is active. It watches keyboard and windows.</string>
+    <string name="security_dialog_start">Start anyway.</string>
+    <string name="security_dialog_start_an_stop_detecting">Don\'t show anymore.</string>
+    <string name="security_dialog_stop">Stop.</string>
+    <string name="detect_notification_listener">Detect if a notification listener is active.</string>
+    <string name="notification_security_dialog_message">A Notification listener reads the content of message notifications. These notifications listeners are active :</string>
+    <string name="security_dialog_continue">Continue.</string>
+    <string name="accessibility_change_security_dialog_message">An accessibility service has been activated. It watches keyboard and windows.</string>
+    <string name="notification_change_security_dialog_message">A Notification listener reads the content of message notifications. These notifications listeners have been activated :</string>
 </resources>

--- a/vector/src/main/res/values/styles.xml
+++ b/vector/src/main/res/values/styles.xml
@@ -748,4 +748,24 @@
         <item name="android:textColorHint">@color/tchap_text_color_light</item>
         <item name="colorAccent">@color/tchap_text_color_light</item>
     </style>
+
+    <!--  ************************  Startup Dark theme  **************************** -->
+
+    <style name="AppTheme.NoActionBar.Startup.Dark" parent="@style/Theme.Vector.Dark">
+        <!-- disable the overscroll because setOverscrollHeader/Footer don't always work -->
+        <item name="android:overScrollMode">never</item>
+
+        <!-- hide the action bar -->
+        <item name="android:windowActionBar">false</item>
+        <item name="windowActionBar">false</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="windowNoTitle">true</item>
+        <item name="android:typeface">sans</item>
+        <item name="android:windowBackground">@color/riot_primary_background_color_dark</item>
+    </style>
+
+    <style name="AppTheme.NoActionBar.Swipe.Startup.Dark" parent="@style/AppTheme.NoActionBar.Startup.Dark">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+    </style>
 </resources>

--- a/vector/src/main/res/xml/vector_settings_preferences.xml
+++ b/vector/src/main/res/xml/vector_settings_preferences.xml
@@ -278,6 +278,15 @@
             android:key="SETTINGS_USE_NATIVE_CAMERA_PREFERENCE_KEY"
             android:title="@string/settings_labs_native_camera" />
 
+        <im.vector.preference.VectorSwitchPreference
+            android:defaultValue="true"
+            android:key="SETTINGS_DETECT_ACCESSIBILITY_SERVICE_KEY"
+            android:title="@string/detect_accessibility_service" />
+
+        <im.vector.preference.VectorSwitchPreference
+            android:defaultValue="true"
+            android:key="SETTINGS_DETECT_NOTIFICATION_LISTENER_KEY"
+            android:title="@string/detect_notification_listener" />
     </im.vector.preference.VectorPreferenceCategory>
 
     <im.vector.preference.VectorDividerCategory /-->


### PR DESCRIPTION
While they can be legitimate to assist users with specific accessibility devices, accessibility services are also known to be used by malwares ([https://thehackernews.com/2017/11/android-accessibility-services.html](https://thehackernews.com/2017/11/android-accessibility-services.html)).

This patch permits to detect such services when the application is launched and if such service is detected, it informs the user, and asks him (only once) if application should start or not.