### PR TITLE
Room creation: Do not prompt the user if the alias is already used

### DIFF
--- a/vector/src/main/res/values-fr/strings.xml
+++ b/vector/src/main/res/values-fr/strings.xml
@@ -858,9 +858,6 @@ Appareils inconnus :</string>
         <item quantity="one">1 invitation a bien été envoyée.</item>
         <item quantity="other">%d invitations ont bien été envoyées.</item>
     </plurals>
-    <string name="tchap_invite_room_alias_invalid_characters_title">Cet alias contient des caractères spéciaux invalides</string>
-    <string name="tchap_invite_room_alias_already_taken_title">Cet alias est déjà pris</string>
-    <string name="tchap_invite_room_alias_already_taken_message">Veuillez le modifier pour finaliser la création du salon.</string>
     <string name="tchap_burger_menu_contacts">Contacts</string>
     <string name="tchap_burger_menu_public_rooms">Salons publics</string>
     <string name="tchap_burger_menu_info">Cette application n\'est pas approuvée\npour l\'échange d\'informations en diffusion restreinte</string>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -965,9 +965,6 @@
         <item quantity="one">1 invitation has been sent.</item>
         <item quantity="other">%d invitations have been sent.</item>
     </plurals>
-    <string name="tchap_invite_room_alias_invalid_characters_title">This alias contains invalid special characters</string>
-    <string name="tchap_invite_room_alias_already_taken_title">This alias is already taken</string>
-    <string name="tchap_invite_room_alias_already_taken_message">Please edit it to finalize the room creation.</string>
     <string name="tchap_burger_menu_contacts">Contacts</string>
     <string name="tchap_burger_menu_public_rooms">Public rooms</string>
     <string name="tchap_burger_menu_info">This app is not approved for\nrestricted information interchange</string>


### PR DESCRIPTION
- handle room alias already taken
- handle room alias with invalid characters
- handle federation denied error

Related to  #249.