### PR TITLE
Handle correctly unreachable contacts

### DIFF
--- a/vector/src/main/java/fr/gouv/tchap/activity/TchapLoginActivity.java
+++ b/vector/src/main/java/fr/gouv/tchap/activity/TchapLoginActivity.java
@@ -2431,14 +2431,14 @@ public class TchapLoginActivity extends MXCActionBarActivity implements Registra
      * @return the home server Url according to current tchap platform.
      */
     private String getHomeServerUrl() {
-        return (null != mTchapPlatform) ? getString(R.string.server_url_prefix) + mTchapPlatform.hs : null;
+        return (null != mTchapPlatform && null != mTchapPlatform.hs) ? getString(R.string.server_url_prefix) + mTchapPlatform.hs : null;
     }
 
     /**
      * @return the identity server URL according to current tchap platform.
      */
     private String getIdentityServerUrl() {
-        return (null != mTchapPlatform) ? getString(R.string.server_url_prefix) + mTchapPlatform.hs : null;
+        return (null != mTchapPlatform && null != mTchapPlatform.hs) ? getString(R.string.server_url_prefix) + mTchapPlatform.hs : null;
     }
 
     /**

--- a/vector/src/main/java/im/vector/activity/VectorRoomInviteMembersActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomInviteMembersActivity.java
@@ -795,6 +795,13 @@ public class VectorRoomInviteMembersActivity extends MXCActionBarActivity implem
 
                     @Override
                     public void onSuccess(Platform platform) {
+                        // Check whether the returned platform is valid
+                        if (null == platform.hs || platform.hs.isEmpty()) {
+                            // The email owner is not able to create a tchap account,
+                            onError(getString(R.string.tchap_invite_unreachable_message, email));
+                            return;
+                        }
+
                         // The email owner is able to create a tchap account,
                         // we create a direct chat with him, and invite him by email to join Tchap.
                         mSession.createDirectMessageRoom(email, new ApiCallback<String>() {


### PR DESCRIPTION
When the Tchap registration is not supported for an email, the server returns an empty host (with code 200).

We handle here correctly this use case