### PR TITLE
fix a bug when leave contact tab and come back, with an active filter

### DIFF
--- a/vector/src/main/java/fr/gouv/tchap/fragments/TchapContactFragment.java
+++ b/vector/src/main/java/fr/gouv/tchap/fragments/TchapContactFragment.java
@@ -153,8 +153,13 @@ public class TchapContactFragment extends AbsHomeFragment implements ContactsMan
         if (!ContactsManager.getInstance().isContactBookAccessRequested()) {
             CommonActivityUtils.checkPermissions(CommonActivityUtils.REQUEST_CODE_PERMISSION_MEMBERS_SEARCH, this);
         }
-
-        initKnownContacts();
+        boolean noSearch = TextUtils.isEmpty(mCurrentFilter);
+        if (noSearch) {
+            initKnownContacts();
+        }
+        else {
+            startRemoteKnownContactsSearch(true);
+        }
     }
 
     @Override


### PR DESCRIPTION
When come back to contact's tab, the app doesn't search again in the server and use the known contacts that are on the phone.