### PR TITLE
Public rooms: turn on the preview by default

### DIFF
--- a/vector/src/main/java/fr/gouv/tchap/activity/TchapRoomCreationActivity.java
+++ b/vector/src/main/java/fr/gouv/tchap/activity/TchapRoomCreationActivity.java
@@ -184,12 +184,14 @@ public class TchapRoomCreationActivity extends MXCActionBarActivity {
             tvPublicPrivateRoomDescription.setTextColor(ContextCompat.getColor(this, R.color.vector_fuchsia_color));
             mRoomParams.visibility = RoomState.DIRECTORY_VISIBILITY_PUBLIC;
             mRoomParams.preset = CreateRoomParams.PRESET_PUBLIC_CHAT;
+            mRoomParams.setHistoryVisibility(RoomState.HISTORY_VISIBILITY_WORLD_READABLE);
             Log.d(LOG_TAG, "## public");
         } else {
             switchPublicPrivateRoom.setChecked(false);
             tvPublicPrivateRoomDescription.setTextColor(ContextCompat.getColor(this, R.color.vector_tchap_text_color_light_grey));
             mRoomParams.visibility = RoomState.DIRECTORY_VISIBILITY_PRIVATE;
             mRoomParams.preset = CreateRoomParams.PRESET_PRIVATE_CHAT;
+            mRoomParams.setHistoryVisibility(null);
             Log.d(LOG_TAG, "## private");
         }
     }


### PR DESCRIPTION
- when creating a public room, set the history visibility to world_readable

Related to  #262