### PR TITLE
Fix crash with media (images/videos) on Android 4.x

### DIFF
--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -189,6 +189,7 @@ dependencies {
 
     implementation 'me.leolin:ShortcutBadger:1.1.2@aar'
 
+    implementation 'com.android.support:support-v4:27.1.1'
     implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'com.android.support:design:27.1.1'
     implementation 'com.android.support:cardview-v7:27.1.1'

--- a/vector/src/main/res/layout/adapter_item_vector_message_image_video.xml
+++ b/vector/src/main/res/layout/adapter_item_vector_message_image_video.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -142,7 +143,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginLeft="10dp"
-                        android:background="@drawable/sticker_description_triangle" />
+                        app:srcCompat="@drawable/sticker_description_triangle" />
 
                     <TextView
                         android:id="@+id/message_adapter_sticker_description"


### PR DESCRIPTION
The preview is now displayed correctly, and application does not crash anymore.
I did not find why nothing happens when I click on it...