### PR TITLE
Fix crash with media (images/videos) on Android 4.x

### DIFF
--- a/vector/src/main/java/im/vector/adapters/VectorMessagesAdapterHelper.java
+++ b/vector/src/main/java/im/vector/adapters/VectorMessagesAdapterHelper.java
@@ -652,12 +652,12 @@ class VectorMessagesAdapterHelper {
      */
     public void showStickerDescription(View view, StickerMessage stickerMessage) {
         View stickerDescriptionLayout = view.findViewById(R.id.message_adapter_sticker_layout);
-        ImageView stickerTriangle = view.findViewById(R.id.message_adapter_sticker_triangle);
+        //ImageView stickerTriangle = view.findViewById(R.id.message_adapter_sticker_triangle);
         TextView stickerDescription = view.findViewById(R.id.message_adapter_sticker_description);
 
-        if (null != stickerDescriptionLayout && null != stickerTriangle && null != stickerDescription) {
+        if (null != stickerDescriptionLayout /*&& null != stickerTriangle*/ && null != stickerDescription) {
             stickerDescriptionLayout.setVisibility(View.VISIBLE);
-            stickerTriangle.setVisibility(View.VISIBLE);
+            //stickerTriangle.setVisibility(View.VISIBLE);
             stickerDescription.setVisibility(View.VISIBLE);
             stickerDescription.setText(stickerMessage.body);
         }

--- a/vector/src/main/res/layout/adapter_item_vector_message_image_video.xml
+++ b/vector/src/main/res/layout/adapter_item_vector_message_image_video.xml
@@ -137,12 +137,12 @@
                     android:orientation="vertical"
                     android:visibility="gone">
 
-                    <ImageView
+                    <!--ImageView
                         android:id="@+id/message_adapter_sticker_triangle"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginLeft="10dp"
-                        android:background="@drawable/sticker_description_triangle" />
+                        android:background="@drawable/sticker_description_triangle" /-->
 
                     <TextView
                         android:id="@+id/message_adapter_sticker_description"


### PR DESCRIPTION
Remove temporarily the vector graphic use to render sticker description
because this item is not supported in some  Android 4.

Note sticker are not supported for the moment

See details in the initial PR #319